### PR TITLE
deps: update axum and axum-server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,13 +32,13 @@ tokio-rustls = { version = "0.24" }
 reqwest = { version = "0.11.19", default-features = false, features = ["rustls-tls"] }
 
 # Axum
-axum-server = { version = "0.5", features = ["tls-rustls"], optional = true }
+axum-server = { version = "0.6", features = ["tls-rustls"], optional = true }
 
 [dev-dependencies]
 simple_logger = "4.1"
 structopt = "0.3.26"
 clap = { version = "4", features = ["derive"] }
-axum = "0.6"
+axum = "0.7"
 tokio = { version="1.19.2", features = ["full"] }
 tokio-stream = { version="0.1.9", features = ["net"] }
 tokio-util = { version="0.7.3", features = ["compat"] }


### PR DESCRIPTION
This bumps the `axum` and `axum-server` dependencies of the optional `axum` feature to the recent versions. Otherwise this crate is not usable with recent axum due to different trait versions.