### PR TITLE
feat: add EAB token support

### DIFF
--- a/src/acme.rs
+++ b/src/acme.rs
@@ -66,12 +66,7 @@ impl Account {
         let contact: Vec<&'a str> = contact.into_iter().map(AsRef::<str>::as_ref).collect();
 
         let payload = if let Some(eab) = &eab.as_ref() {
-            let eab_body = sign_eab(
-                &key_pair,
-                &eab.key,
-                &eab.kid,
-                &directory.new_account,
-            )?;
+            let eab_body = sign_eab(&key_pair, &eab.key, &eab.kid, &directory.new_account)?;
 
             json!({
                 "termsOfServiceAgreed": true,
@@ -83,7 +78,8 @@ impl Account {
                 "termsOfServiceAgreed": true,
                 "contact": contact,
             })
-        }.to_string();
+        }
+        .to_string();
 
         let body = sign(
             &key_pair,

--- a/src/acme.rs
+++ b/src/acme.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use crate::https_helper::{https, HttpsRequestError, Method, Response};
-use crate::jose::{key_authorization_sha256, sign, JoseError};
+use crate::jose::{key_authorization_sha256, sign, sign_eab, JoseError};
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
 use rcgen::{CustomExtension, Error as RcgenError, PKCS_ECDSA_P256_SHA256};
@@ -42,19 +42,21 @@ impl Account {
         client_config: &Arc<ClientConfig>,
         directory: Directory,
         contact: I,
+        eab: &Option<ExternalAccountKey>,
     ) -> Result<Self, AcmeError>
     where
         S: AsRef<str> + 'a,
         I: IntoIterator<Item = &'a S>,
     {
         let key_pair = Self::generate_key_pair();
-        Self::create_with_keypair(client_config, directory, contact, &key_pair).await
+        Self::create_with_keypair(client_config, directory, contact, &key_pair, eab).await
     }
     pub async fn create_with_keypair<'a, S, I>(
         client_config: &Arc<ClientConfig>,
         directory: Directory,
         contact: I,
         key_pair: &[u8],
+        eab: &Option<ExternalAccountKey>,
     ) -> Result<Self, AcmeError>
     where
         S: AsRef<str> + 'a,
@@ -62,11 +64,27 @@ impl Account {
     {
         let key_pair = EcdsaKeyPair::from_pkcs8(ALG, key_pair, &SystemRandom::new())?;
         let contact: Vec<&'a str> = contact.into_iter().map(AsRef::<str>::as_ref).collect();
-        let payload = json!({
-            "termsOfServiceAgreed": true,
-            "contact": contact,
-        })
-        .to_string();
+
+        let payload = if let Some(eab) = &eab.as_ref() {
+            let eab_body = sign_eab(
+                &key_pair,
+                &eab.key,
+                &eab.kid,
+                &directory.new_account,
+            )?;
+
+            json!({
+                "termsOfServiceAgreed": true,
+                "contact": contact,
+                "externalAccountBinding": eab_body,
+            })
+        } else {
+            json!({
+                "termsOfServiceAgreed": true,
+                "contact": contact,
+            })
+        }.to_string();
+
         let body = sign(
             &key_pair,
             None,
@@ -213,6 +231,21 @@ impl Directory {
     pub async fn nonce(&self, client_config: &Arc<ClientConfig>) -> Result<String, AcmeError> {
         let response = &https(client_config, &self.new_nonce.as_str(), Method::Head, None).await?;
         get_header(response, "replay-nonce")
+    }
+}
+
+/// See RFC 8555 section 7.3.4 for more information.
+pub struct ExternalAccountKey {
+    pub kid: String,
+    pub key: ring::hmac::Key,
+}
+
+impl ExternalAccountKey {
+    pub fn new(kid: String, key: &[u8]) -> Self {
+        Self {
+            kid,
+            key: ring::hmac::Key::new(ring::hmac::HMAC_SHA256, key),
+        }
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,6 @@
-use crate::acme::{ExternalAccountKey, LETS_ENCRYPT_PRODUCTION_DIRECTORY, LETS_ENCRYPT_STAGING_DIRECTORY};
+use crate::acme::{
+    ExternalAccountKey, LETS_ENCRYPT_PRODUCTION_DIRECTORY, LETS_ENCRYPT_STAGING_DIRECTORY,
+};
 use crate::caches::{BoxedErrCache, CompositeCache, NoCache};
 use crate::{AccountCache, Cache, CertCache};
 use crate::{AcmeState, Incoming};
@@ -104,7 +106,7 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeConfig<EC, EA> {
     }
 
     pub fn external_account_binding(mut self, kid: impl AsRef<str>, key: impl AsRef<[u8]>) -> Self {
-        self.eab = Some(ExternalAccountKey::new(kid.as_ref().into(), key.as_ref().into()));
+        self.eab = Some(ExternalAccountKey::new(kid.as_ref().into(), key.as_ref()));
         self
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,4 +1,4 @@
-use crate::acme::{LETS_ENCRYPT_PRODUCTION_DIRECTORY, LETS_ENCRYPT_STAGING_DIRECTORY};
+use crate::acme::{ExternalAccountKey, LETS_ENCRYPT_PRODUCTION_DIRECTORY, LETS_ENCRYPT_STAGING_DIRECTORY};
 use crate::caches::{BoxedErrCache, CompositeCache, NoCache};
 use crate::{AccountCache, Cache, CertCache};
 use crate::{AcmeState, Incoming};
@@ -19,6 +19,7 @@ pub struct AcmeConfig<EC: Debug, EA: Debug = EC> {
     pub(crate) domains: Vec<String>,
     pub(crate) contact: Vec<String>,
     pub(crate) cache: Box<dyn Cache<EC = EC, EA = EA>>,
+    pub(crate) eab: Option<ExternalAccountKey>,
 }
 
 impl AcmeConfig<Infallible, Infallible> {
@@ -70,6 +71,7 @@ impl AcmeConfig<Infallible, Infallible> {
             domains: domains.into_iter().map(|s| s.as_ref().into()).collect(),
             contact: vec![],
             cache: Box::new(NoCache::new()),
+            eab: None,
         }
     }
 }
@@ -101,6 +103,11 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeConfig<EC, EA> {
         self
     }
 
+    pub fn external_account_binding(mut self, kid: impl AsRef<str>, key: impl AsRef<[u8]>) -> Self {
+        self.eab = Some(ExternalAccountKey::new(kid.as_ref().into(), key.as_ref().into()));
+        self
+    }
+
     /// Provide a list of contacts for the account.
     ///
     /// Note that email addresses must include a `mailto:` prefix.
@@ -124,6 +131,7 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeConfig<EC, EA> {
             domains: self.domains,
             contact: self.contact,
             cache: Box::new(cache),
+            eab: self.eab,
         }
     }
     pub fn cache_compose<CC: 'static + CertCache, CA: 'static + AccountCache>(

--- a/src/jose.rs
+++ b/src/jose.rs
@@ -17,7 +17,7 @@ pub(crate) fn sign(
         None => Some(Jwk::new(key)),
         Some(_) => None,
     };
-    let protected = Protected::base64(jwk, kid, nonce, url)?;
+    let protected = Protected::base64(jwk, kid, Some(nonce.as_ref()), url)?;
     let payload = URL_SAFE_NO_PAD.encode(payload);
     let combined = format!("{}.{}", &protected, &payload);
     let signature = key.sign(&SystemRandom::new(), combined.as_bytes())?;
@@ -30,6 +30,25 @@ pub(crate) fn sign(
     Ok(serde_json::to_string(&body)?)
 }
 
+pub(crate) fn sign_eab(
+    key: &EcdsaKeyPair,
+    eab_key: &ring::hmac::Key,
+    kid: &str,
+    url: &str,
+) -> Result<Body, JoseError> {
+    let protected = Protected::hmac_base64(kid, url)?;
+    let payload = URL_SAFE_NO_PAD.encode(serde_json::to_vec(&Jwk::new(key))?);
+    let combined = format!("{}.{}", &protected, &payload);
+    let signature = ring::hmac::sign(eab_key, combined.as_bytes());
+    let signature = URL_SAFE_NO_PAD.encode(signature.as_ref());
+    let body = Body {
+        protected,
+        payload,
+        signature,
+    };
+    Ok(body)
+}
+
 pub(crate) fn key_authorization_sha256(
     key: &EcdsaKeyPair,
     token: &str,
@@ -40,7 +59,7 @@ pub(crate) fn key_authorization_sha256(
 }
 
 #[derive(Serialize)]
-struct Body {
+pub(crate) struct Body {
     protected: String,
     payload: String,
     signature: String,
@@ -53,7 +72,8 @@ struct Protected<'a> {
     jwk: Option<Jwk>,
     #[serde(skip_serializing_if = "Option::is_none")]
     kid: Option<&'a str>,
-    nonce: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    nonce: Option<&'a str>,
     url: &'a str,
 }
 
@@ -61,7 +81,7 @@ impl<'a> Protected<'a> {
     fn base64(
         jwk: Option<Jwk>,
         kid: Option<&'a str>,
-        nonce: String,
+        nonce: Option<&'a str>,
         url: &'a str,
     ) -> Result<String, JoseError> {
         let protected = Self {
@@ -69,6 +89,21 @@ impl<'a> Protected<'a> {
             jwk,
             kid,
             nonce,
+            url,
+        };
+        let protected = serde_json::to_vec(&protected)?;
+        Ok(URL_SAFE_NO_PAD.encode(protected))
+    }
+
+    fn hmac_base64(
+        kid: &'a str,
+        url: &'a str,
+    ) -> Result<String, JoseError> {
+        let protected = Self {
+            alg: "HS256",
+            jwk: None,
+            kid: Some(kid),
+            nonce: None,
             url,
         };
         let protected = serde_json::to_vec(&protected)?;

--- a/src/jose.rs
+++ b/src/jose.rs
@@ -95,10 +95,7 @@ impl<'a> Protected<'a> {
         Ok(URL_SAFE_NO_PAD.encode(protected))
     }
 
-    fn hmac_base64(
-        kid: &'a str,
-        url: &'a str,
-    ) -> Result<String, JoseError> {
+    fn hmac_base64(kid: &'a str, url: &'a str) -> Result<String, JoseError> {
         let protected = Self {
             alg: "HS256",
             jwk: None,

--- a/src/state.rs
+++ b/src/state.rs
@@ -228,6 +228,7 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
             directory,
             &config.contact,
             &key_pair,
+            &config.eab,
         )
         .await?;
 


### PR DESCRIPTION
Add support for External Account Binding (aka EAB) tokens, as defined in section 7.3.4 of RFC 8555. EAB tokens allows an ACME workflow to be associated with a pre-existing account at a CA. And it's required for CA that enforce them, like ZeroSSL.

FWIW, I have pretty high confidence in the correctness of JWS signing and other related cryptography operation, but I am not a Rust developer and can't speak to the quality of the rust code.