### PR TITLE
feat: support alternate chains

### DIFF
--- a/docker-compose.pebble.yml
+++ b/docker-compose.pebble.yml
@@ -10,4 +10,5 @@ services:
     environment:
       PEBBLE_VA_NOSLEEP: "1"
       PEBBLE_VA_ALWAYS_VALID: "1"
+      PEBBLE_ALTERNATE_ROOTS: "1"
       PEBBLE_WFE_NONCEREJECT: "0"

--- a/src/acme.rs
+++ b/src/acme.rs
@@ -190,7 +190,7 @@ impl Account {
             alternate_urls,
         })
     }
-    pub async fn certificate_from_url(
+    pub async fn certificate(
         &self,
         client_config: &Arc<ClientConfig>,
         url: impl AsRef<str>,

--- a/src/acme.rs
+++ b/src/acme.rs
@@ -174,6 +174,27 @@ impl Account {
         &self,
         client_config: &Arc<ClientConfig>,
         url: impl AsRef<str>,
+    ) -> Result<CertificateResponse, AcmeError> {
+        let body = sign(
+            &self.key_pair,
+            Some(&self.kid),
+            self.directory.nonce(client_config).await?,
+            url.as_ref(),
+            "",
+        )?;
+        let response = https(client_config, url.as_ref(), Method::Post, Some(body)).await?;
+        let alternate_urls = parse_link_alternate(&response);
+        let pem = response.text().await.map_err(HttpsRequestError::from)?;
+        log::debug!("certificate response: {pem:?}");
+        Ok(CertificateResponse {
+            pem,
+            alternate_urls,
+        })
+    }
+    pub async fn certificate_from_url(
+        &self,
+        client_config: &Arc<ClientConfig>,
+        url: impl AsRef<str>,
     ) -> Result<String, AcmeError> {
         Ok(self.request(client_config, &url, "").await?.1)
     }
@@ -341,6 +362,41 @@ pub enum AcmeError {
     MissingHeader(&'static str),
     #[error("no tls-alpn-01 challenge found")]
     NoTlsAlpn01Challenge,
+}
+
+/// The response from downloading a certificate, including any alternate chain URLs.
+pub struct CertificateResponse {
+    /// The PEM-encoded certificate chain.
+    pub pem: String,
+    /// URLs of alternate certificate chains (from `Link: <url>;rel="alternate"` headers).
+    pub alternate_urls: Vec<String>,
+}
+
+/// Parse `Link` headers for `rel="alternate"` URLs (RFC 8555 Section 7.4.2).
+fn parse_link_alternate(response: &Response) -> Vec<String> {
+    let mut urls = Vec::new();
+    for value in response.headers().get_all("Link").iter() {
+        let Ok(value) = value.to_str() else {
+            continue;
+        };
+        // Handle comma-separated Link values and individual headers.
+        // Format: <https://...>;rel="alternate"
+        for part in value.split(',') {
+            let part = part.trim();
+            if !part.contains("rel=\"alternate\"") {
+                continue;
+            }
+            if let Some(url) = part
+                .split(';')
+                .next()
+                .and_then(|s| s.trim().strip_prefix('<'))
+                .and_then(|s| s.strip_suffix('>'))
+            {
+                urls.push(url.to_string());
+            }
+        }
+    }
+    urls
 }
 
 fn get_header(response: &Response, header: &'static str) -> Result<String, AcmeError> {

--- a/src/acme.rs
+++ b/src/acme.rs
@@ -5,6 +5,7 @@ use crate::jose::{key_authorization_sha256, sign, sign_eab, JoseError};
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
 use rcgen::{CustomExtension, Error as RcgenError, PKCS_ECDSA_P256_SHA256};
+use reqwest::header::HeaderMap;
 use ring::error::{KeyRejected, Unspecified};
 use ring::rand::SystemRandom;
 use ring::signature::{EcdsaKeyPair, EcdsaSigningAlgorithm, ECDSA_P256_SHA256_FIXED_SIGNING};
@@ -107,7 +108,7 @@ impl Account {
         client_config: &Arc<ClientConfig>,
         url: impl AsRef<str>,
         payload: &str,
-    ) -> Result<(Option<String>, String), AcmeError> {
+    ) -> Result<ApiResponse, AcmeError> {
         let body = sign(
             &self.key_pair,
             Some(&self.kid),
@@ -117,9 +118,14 @@ impl Account {
         )?;
         let response = https(client_config, url.as_ref(), Method::Post, Some(body)).await?;
         let location = get_header(&response, "Location").ok();
+        let headers = response.headers().clone();
         let body = response.text().await.map_err(HttpsRequestError::from)?;
         log::debug!("response: {body:?}");
-        Ok((location, body))
+        Ok(ApiResponse {
+            body,
+            location,
+            headers,
+        })
     }
     pub async fn new_order(
         &self,
@@ -131,8 +137,10 @@ impl Account {
         let response = self
             .request(client_config, &self.directory.new_order, &payload)
             .await?;
-        let url = response.0.ok_or(AcmeError::MissingHeader("Location"))?;
-        let order = serde_json::from_str(&response.1)?;
+        let url = response
+            .location
+            .ok_or(AcmeError::MissingHeader("Location"))?;
+        let order = serde_json::from_str(&response.body)?;
         Ok((url, order))
     }
     pub async fn auth(
@@ -142,7 +150,7 @@ impl Account {
     ) -> Result<Auth, AcmeError> {
         let payload = "".to_string();
         let response = self.request(client_config, url, &payload).await?;
-        Ok(serde_json::from_str(&response.1)?)
+        Ok(serde_json::from_str(&response.body)?)
     }
     pub async fn challenge(
         &self,
@@ -158,7 +166,7 @@ impl Account {
         url: impl AsRef<str>,
     ) -> Result<Order, AcmeError> {
         let response = self.request(client_config, &url, "").await?;
-        Ok(serde_json::from_str(&response.1)?)
+        Ok(serde_json::from_str(&response.body)?)
     }
     pub async fn finalize(
         &self,
@@ -168,26 +176,17 @@ impl Account {
     ) -> Result<Order, AcmeError> {
         let payload = format!("{{\"csr\":\"{}\"}}", URL_SAFE_NO_PAD.encode(csr),);
         let response = self.request(client_config, &url, &payload).await?;
-        Ok(serde_json::from_str(&response.1)?)
+        Ok(serde_json::from_str(&response.body)?)
     }
-    pub async fn certificate(
+    pub async fn certificate_with_alternate_urls(
         &self,
         client_config: &Arc<ClientConfig>,
         url: impl AsRef<str>,
-    ) -> Result<CertificateResponse, AcmeError> {
-        let body = sign(
-            &self.key_pair,
-            Some(&self.kid),
-            self.directory.nonce(client_config).await?,
-            url.as_ref(),
-            "",
-        )?;
-        let response = https(client_config, url.as_ref(), Method::Post, Some(body)).await?;
-        let alternate_urls = parse_link_alternate(&response);
-        let pem = response.text().await.map_err(HttpsRequestError::from)?;
-        log::debug!("certificate response: {pem:?}");
-        Ok(CertificateResponse {
-            pem,
+    ) -> Result<CertificateWithAlternateUrls, AcmeError> {
+        let response = self.request(client_config, url, "").await?;
+        let alternate_urls = parse_link_alternate(&response.headers);
+        Ok(CertificateWithAlternateUrls {
+            pem: response.body,
             alternate_urls,
         })
     }
@@ -196,7 +195,7 @@ impl Account {
         client_config: &Arc<ClientConfig>,
         url: impl AsRef<str>,
     ) -> Result<String, AcmeError> {
-        Ok(self.request(client_config, &url, "").await?.1)
+        Ok(self.request(client_config, &url, "").await?.body)
     }
     pub fn tls_alpn_01<'a>(
         &self,
@@ -364,8 +363,14 @@ pub enum AcmeError {
     NoTlsAlpn01Challenge,
 }
 
+struct ApiResponse {
+    body: String,
+    location: Option<String>,
+    headers: HeaderMap,
+}
+
 /// The response from downloading a certificate, including any alternate chain URLs.
-pub struct CertificateResponse {
+pub struct CertificateWithAlternateUrls {
     /// The PEM-encoded certificate chain.
     pub pem: String,
     /// URLs of alternate certificate chains (from `Link: <url>;rel="alternate"` headers).
@@ -373,9 +378,9 @@ pub struct CertificateResponse {
 }
 
 /// Parse `Link` headers for `rel="alternate"` URLs (RFC 8555 Section 7.4.2).
-fn parse_link_alternate(response: &Response) -> Vec<String> {
+fn parse_link_alternate(headers: &HeaderMap) -> Vec<String> {
     let mut urls = Vec::new();
-    for value in response.headers().get_all("Link").iter() {
+    for value in headers.get_all("Link").iter() {
         let Ok(value) = value.to_str() else {
             continue;
         };

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -6,6 +6,18 @@ pub trait Cache: CertCache + AccountCache {}
 
 impl<T> Cache for T where T: CertCache + AccountCache {}
 
+/// Identifies which certificate chain variant to load or store.
+///
+/// ACME servers may offer multiple certificate chains for the same certificate
+/// (see [RFC 8555 Section 7.4.2](https://datatracker.ietf.org/doc/html/rfc8555#section-7.4.2)).
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash)]
+pub enum CertChainKind {
+    /// The default (primary) certificate chain.
+    Default,
+    /// An alternate certificate chain (e.g., from `Link: rel="alternate"` headers).
+    Alternate,
+}
+
 #[async_trait]
 pub trait CertCache: Send + Sync {
     type EC: Debug;
@@ -13,35 +25,15 @@ pub trait CertCache: Send + Sync {
         &self,
         domains: &[String],
         directory_url: &str,
+        chain: CertChainKind,
     ) -> Result<Option<Vec<u8>>, Self::EC>;
-
     async fn store_cert(
         &self,
         domains: &[String],
         directory_url: &str,
+        chain: CertChainKind,
         cert: &[u8],
     ) -> Result<(), Self::EC>;
-
-    /// Load an alternate certificate chain (used for [`DualChain`](crate::CertChainPreference::DualChain) mode).
-    /// Default implementation returns `Ok(None)`.
-    async fn load_alt_cert(
-        &self,
-        _domains: &[String],
-        _directory_url: &str,
-    ) -> Result<Option<Vec<u8>>, Self::EC> {
-        Ok(None)
-    }
-
-    /// Store an alternate certificate chain (used for [`DualChain`](crate::CertChainPreference::DualChain) mode).
-    /// Default implementation is a no-op.
-    async fn store_alt_cert(
-        &self,
-        _domains: &[String],
-        _directory_url: &str,
-        _cert: &[u8],
-    ) -> Result<(), Self::EC> {
-        Ok(())
-    }
 }
 
 #[async_trait]

--- a/src/cache.rs
+++ b/src/cache.rs
@@ -14,12 +14,34 @@ pub trait CertCache: Send + Sync {
         domains: &[String],
         directory_url: &str,
     ) -> Result<Option<Vec<u8>>, Self::EC>;
+
     async fn store_cert(
         &self,
         domains: &[String],
         directory_url: &str,
         cert: &[u8],
     ) -> Result<(), Self::EC>;
+
+    /// Load an alternate certificate chain (used for [`DualChain`](crate::CertChainPreference::DualChain) mode).
+    /// Default implementation returns `Ok(None)`.
+    async fn load_alt_cert(
+        &self,
+        _domains: &[String],
+        _directory_url: &str,
+    ) -> Result<Option<Vec<u8>>, Self::EC> {
+        Ok(None)
+    }
+
+    /// Store an alternate certificate chain (used for [`DualChain`](crate::CertChainPreference::DualChain) mode).
+    /// Default implementation is a no-op.
+    async fn store_alt_cert(
+        &self,
+        _domains: &[String],
+        _directory_url: &str,
+        _cert: &[u8],
+    ) -> Result<(), Self::EC> {
+        Ok(())
+    }
 }
 
 #[async_trait]

--- a/src/caches/boxed.rs
+++ b/src/caches/boxed.rs
@@ -47,6 +47,27 @@ where
             .await
             .map_err(box_err)
     }
+    async fn load_alt_cert(
+        &self,
+        domains: &[String],
+        directory_url: &str,
+    ) -> Result<Option<Vec<u8>>, Self::EC> {
+        self.inner
+            .load_alt_cert(domains, directory_url)
+            .await
+            .map_err(box_err)
+    }
+    async fn store_alt_cert(
+        &self,
+        domains: &[String],
+        directory_url: &str,
+        cert: &[u8],
+    ) -> Result<(), Self::EC> {
+        self.inner
+            .store_alt_cert(domains, directory_url, cert)
+            .await
+            .map_err(box_err)
+    }
 }
 
 #[async_trait]

--- a/src/caches/boxed.rs
+++ b/src/caches/boxed.rs
@@ -1,4 +1,4 @@
-use crate::{AccountCache, CertCache};
+use crate::{AccountCache, CertCache, CertChainKind};
 use async_trait::async_trait;
 use std::fmt::Debug;
 
@@ -29,9 +29,10 @@ where
         &self,
         domains: &[String],
         directory_url: &str,
+        chain: CertChainKind,
     ) -> Result<Option<Vec<u8>>, Self::EC> {
         self.inner
-            .load_cert(domains, directory_url)
+            .load_cert(domains, directory_url, chain)
             .await
             .map_err(box_err)
     }
@@ -40,31 +41,11 @@ where
         &self,
         domains: &[String],
         directory_url: &str,
+        chain: CertChainKind,
         cert: &[u8],
     ) -> Result<(), Self::EC> {
         self.inner
-            .store_cert(domains, directory_url, cert)
-            .await
-            .map_err(box_err)
-    }
-    async fn load_alt_cert(
-        &self,
-        domains: &[String],
-        directory_url: &str,
-    ) -> Result<Option<Vec<u8>>, Self::EC> {
-        self.inner
-            .load_alt_cert(domains, directory_url)
-            .await
-            .map_err(box_err)
-    }
-    async fn store_alt_cert(
-        &self,
-        domains: &[String],
-        directory_url: &str,
-        cert: &[u8],
-    ) -> Result<(), Self::EC> {
-        self.inner
-            .store_alt_cert(domains, directory_url, cert)
+            .store_cert(domains, directory_url, chain, cert)
             .await
             .map_err(box_err)
     }

--- a/src/caches/composite.rs
+++ b/src/caches/composite.rs
@@ -1,4 +1,4 @@
-use crate::{AccountCache, CertCache};
+use crate::{AccountCache, CertCache, CertChainKind};
 use async_trait::async_trait;
 
 pub struct CompositeCache<C: CertCache + Send + Sync, A: AccountCache + Send + Sync> {
@@ -25,37 +25,22 @@ impl<C: CertCache + Send + Sync, A: AccountCache + Send + Sync> CertCache for Co
         &self,
         domains: &[String],
         directory_url: &str,
+        chain: CertChainKind,
     ) -> Result<Option<Vec<u8>>, Self::EC> {
-        self.cert_cache.load_cert(domains, directory_url).await
+        self.cert_cache
+            .load_cert(domains, directory_url, chain)
+            .await
     }
 
     async fn store_cert(
         &self,
         domains: &[String],
         directory_url: &str,
+        chain: CertChainKind,
         cert: &[u8],
     ) -> Result<(), Self::EC> {
         self.cert_cache
-            .store_cert(domains, directory_url, cert)
-            .await
-    }
-    async fn load_alt_cert(
-        &self,
-        domains: &[String],
-        directory_url: &str,
-    ) -> Result<Option<Vec<u8>>, Self::EC> {
-        self.cert_cache
-            .load_alt_cert(domains, directory_url)
-            .await
-    }
-    async fn store_alt_cert(
-        &self,
-        domains: &[String],
-        directory_url: &str,
-        cert: &[u8],
-    ) -> Result<(), Self::EC> {
-        self.cert_cache
-            .store_alt_cert(domains, directory_url, cert)
+            .store_cert(domains, directory_url, chain, cert)
             .await
     }
 }

--- a/src/caches/composite.rs
+++ b/src/caches/composite.rs
@@ -39,6 +39,25 @@ impl<C: CertCache + Send + Sync, A: AccountCache + Send + Sync> CertCache for Co
             .store_cert(domains, directory_url, cert)
             .await
     }
+    async fn load_alt_cert(
+        &self,
+        domains: &[String],
+        directory_url: &str,
+    ) -> Result<Option<Vec<u8>>, Self::EC> {
+        self.cert_cache
+            .load_alt_cert(domains, directory_url)
+            .await
+    }
+    async fn store_alt_cert(
+        &self,
+        domains: &[String],
+        directory_url: &str,
+        cert: &[u8],
+    ) -> Result<(), Self::EC> {
+        self.cert_cache
+            .store_alt_cert(domains, directory_url, cert)
+            .await
+    }
 }
 
 #[async_trait]

--- a/src/caches/dir.rs
+++ b/src/caches/dir.rs
@@ -58,6 +58,16 @@ impl<P: AsRef<Path> + Send + Sync> DirCache<P> {
         let hash = URL_SAFE_NO_PAD.encode(ctx.finish());
         format!("cached_cert_{hash}")
     }
+    fn cached_alt_cert_file_name(domains: &[String], directory_url: impl AsRef<str>) -> String {
+        let mut ctx = Context::new(&SHA256);
+        for domain in domains {
+            ctx.update(domain.as_ref());
+            ctx.update(&[0])
+        }
+        ctx.update(directory_url.as_ref().as_bytes());
+        let hash = URL_SAFE_NO_PAD.encode(ctx.finish());
+        format!("cached_cert_{hash}_alt")
+    }
 }
 
 #[async_trait]
@@ -78,6 +88,23 @@ impl<P: AsRef<Path> + Send + Sync> CertCache for DirCache<P> {
         cert: &[u8],
     ) -> Result<(), Self::EC> {
         let file_name = Self::cached_cert_file_name(domains, directory_url);
+        self.write(file_name, cert).await
+    }
+    async fn load_alt_cert(
+        &self,
+        domains: &[String],
+        directory_url: &str,
+    ) -> Result<Option<Vec<u8>>, Self::EC> {
+        let file_name = Self::cached_alt_cert_file_name(domains, directory_url);
+        self.read_if_exist(file_name).await
+    }
+    async fn store_alt_cert(
+        &self,
+        domains: &[String],
+        directory_url: &str,
+        cert: &[u8],
+    ) -> Result<(), Self::EC> {
+        let file_name = Self::cached_alt_cert_file_name(domains, directory_url);
         self.write(file_name, cert).await
     }
 }

--- a/src/caches/dir.rs
+++ b/src/caches/dir.rs
@@ -1,4 +1,4 @@
-use crate::{AccountCache, CertCache};
+use crate::{AccountCache, CertCache, CertChainKind};
 use async_trait::async_trait;
 use base64::engine::general_purpose::URL_SAFE_NO_PAD;
 use base64::Engine;
@@ -48,7 +48,11 @@ impl<P: AsRef<Path> + Send + Sync> DirCache<P> {
         let hash = URL_SAFE_NO_PAD.encode(ctx.finish());
         format!("cached_account_{hash}")
     }
-    fn cached_cert_file_name(domains: &[String], directory_url: impl AsRef<str>) -> String {
+    fn cached_cert_file_name(
+        domains: &[String],
+        directory_url: impl AsRef<str>,
+        chain: CertChainKind,
+    ) -> String {
         let mut ctx = Context::new(&SHA256);
         for domain in domains {
             ctx.update(domain.as_ref());
@@ -56,17 +60,10 @@ impl<P: AsRef<Path> + Send + Sync> DirCache<P> {
         }
         ctx.update(directory_url.as_ref().as_bytes());
         let hash = URL_SAFE_NO_PAD.encode(ctx.finish());
-        format!("cached_cert_{hash}")
-    }
-    fn cached_alt_cert_file_name(domains: &[String], directory_url: impl AsRef<str>) -> String {
-        let mut ctx = Context::new(&SHA256);
-        for domain in domains {
-            ctx.update(domain.as_ref());
-            ctx.update(&[0])
+        match chain {
+            CertChainKind::Default => format!("cached_cert_{hash}"),
+            CertChainKind::Alternate => format!("cached_cert_{hash}_alt"),
         }
-        ctx.update(directory_url.as_ref().as_bytes());
-        let hash = URL_SAFE_NO_PAD.encode(ctx.finish());
-        format!("cached_cert_{hash}_alt")
     }
 }
 
@@ -77,34 +74,19 @@ impl<P: AsRef<Path> + Send + Sync> CertCache for DirCache<P> {
         &self,
         domains: &[String],
         directory_url: &str,
+        chain: CertChainKind,
     ) -> Result<Option<Vec<u8>>, Self::EC> {
-        let file_name = Self::cached_cert_file_name(domains, directory_url);
+        let file_name = Self::cached_cert_file_name(domains, directory_url, chain);
         self.read_if_exist(file_name).await
     }
     async fn store_cert(
         &self,
         domains: &[String],
         directory_url: &str,
+        chain: CertChainKind,
         cert: &[u8],
     ) -> Result<(), Self::EC> {
-        let file_name = Self::cached_cert_file_name(domains, directory_url);
-        self.write(file_name, cert).await
-    }
-    async fn load_alt_cert(
-        &self,
-        domains: &[String],
-        directory_url: &str,
-    ) -> Result<Option<Vec<u8>>, Self::EC> {
-        let file_name = Self::cached_alt_cert_file_name(domains, directory_url);
-        self.read_if_exist(file_name).await
-    }
-    async fn store_alt_cert(
-        &self,
-        domains: &[String],
-        directory_url: &str,
-        cert: &[u8],
-    ) -> Result<(), Self::EC> {
-        let file_name = Self::cached_alt_cert_file_name(domains, directory_url);
+        let file_name = Self::cached_cert_file_name(domains, directory_url, chain);
         self.write(file_name, cert).await
     }
 }

--- a/src/caches/no.rs
+++ b/src/caches/no.rs
@@ -40,6 +40,7 @@ impl<EC: Debug, EA: Debug> CertCache for NoCache<EC, EA> {
         &self,
         _domains: &[String],
         _directory_url: &str,
+        _chain: crate::CertChainKind,
     ) -> Result<Option<Vec<u8>>, Self::EC> {
         log::info!("no cert cache configured, could not load certificate");
         Ok(None)
@@ -48,6 +49,7 @@ impl<EC: Debug, EA: Debug> CertCache for NoCache<EC, EA> {
         &self,
         _domains: &[String],
         _directory_url: &str,
+        _chain: crate::CertChainKind,
         _cert: &[u8],
     ) -> Result<(), Self::EC> {
         log::info!("no cert cache configured, could not store certificate");

--- a/src/caches/test.rs
+++ b/src/caches/test.rs
@@ -73,6 +73,7 @@ impl<EC: Debug, EA: Debug> CertCache for TestCache<EC, EA> {
         &self,
         domains: &[String],
         _directory_url: &str,
+        _chain: crate::CertChainKind,
     ) -> Result<Option<Vec<u8>>, Self::EC> {
         let key_pair = rcgen::KeyPair::generate_for(&PKCS_ECDSA_P256_SHA256).unwrap();
         let mut params = CertificateParams::new(domains).unwrap();
@@ -106,6 +107,7 @@ impl<EC: Debug, EA: Debug> CertCache for TestCache<EC, EA> {
         &self,
         _domains: &[String],
         _directory_url: &str,
+        _chain: crate::CertChainKind,
         _cert: &[u8],
     ) -> Result<(), Self::EC> {
         log::info!("test cache configured, could not store certificate");

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,8 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncWrite};
 
+const LETSENCRYPT_ISRG_ROOT_X2: &str = "ISRG Root X2";
+
 /// Controls which certificate chain to serve to clients.
 ///
 /// ACME servers like Let's Encrypt may offer multiple certificate chains with different root
@@ -19,8 +21,7 @@ use tokio::io::{AsyncRead, AsyncWrite};
 /// # Note
 ///
 /// For [`DualChain`](CertChainPreference::DualChain), chain selection is currently based on the
-/// client's advertised signature schemes. A server-side preference setting may be added in the
-/// future to give operators more control over chain selection logic.
+/// client's advertised signature schemes.
 #[derive(Clone, Debug, Default)]
 pub enum CertChainPreference {
     /// Use the default chain from the ACME server (typically cross-signed for broad compatibility).
@@ -30,21 +31,19 @@ pub enum CertChainPreference {
     /// string. Falls back to the default chain if no matching alternate is found.
     PreferredChain(String),
     /// Serve two chains, selecting per-client based on TLS capabilities. The string specifies the
-    /// alternate chain's root issuer common name. The default ACME chain is used as the primary
-    /// (broad compatibility). Clients whose advertised signature schemes include no RSA schemes
-    /// receive the alternate chain; all others receive the default chain.
+    /// alternate chain's root issuer common name. The default ACME chain is used as the primary.
     DualChain(String),
 }
 
 impl CertChainPreference {
     /// Use Let's Encrypt ISRG Root X2 (ECDSA-only chain, no RSA).
     pub fn letsencrypt_x2() -> Self {
-        Self::PreferredChain("ISRG Root X2".into())
+        Self::PreferredChain(LETSENCRYPT_ISRG_ROOT_X2.to_owned())
     }
     /// Serve both Let's Encrypt X1 (RSA cross-signed, broad compatibility) and X2 (ECDSA-only)
     /// chains, selecting per-client based on advertised signature schemes.
-    pub fn letsencrypt_x1_x2() -> Self {
-        Self::DualChain("ISRG Root X2".into())
+    pub fn letsencrypt_dual_chain() -> Self {
+        Self::DualChain(LETSENCRYPT_ISRG_ROOT_X2.to_owned())
     }
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,43 @@ use std::fmt::Debug;
 use std::sync::Arc;
 use tokio::io::{AsyncRead, AsyncWrite};
 
+/// Controls which certificate chain to serve to clients.
+///
+/// ACME servers like Let's Encrypt may offer multiple certificate chains with different root
+/// certificates. This enum allows selecting which chain(s) to use.
+///
+/// # Note
+///
+/// For [`DualChain`](CertChainPreference::DualChain), chain selection is currently based on the
+/// client's advertised signature schemes. A server-side preference setting may be added in the
+/// future to give operators more control over chain selection logic.
+#[derive(Clone, Debug, Default)]
+pub enum CertChainPreference {
+    /// Use the default chain from the ACME server (typically cross-signed for broad compatibility).
+    #[default]
+    Default,
+    /// Prefer an alternate chain whose root certificate's subject common name matches the given
+    /// string. Falls back to the default chain if no matching alternate is found.
+    PreferredChain(String),
+    /// Serve two chains, selecting per-client based on TLS capabilities. The string specifies the
+    /// alternate chain's root issuer common name. The default ACME chain is used as the primary
+    /// (broad compatibility). Clients whose advertised signature schemes include no RSA schemes
+    /// receive the alternate chain; all others receive the default chain.
+    DualChain(String),
+}
+
+impl CertChainPreference {
+    /// Use Let's Encrypt ISRG Root X2 (ECDSA-only chain, no RSA).
+    pub fn letsencrypt_x2() -> Self {
+        Self::PreferredChain("ISRG Root X2".into())
+    }
+    /// Serve both Let's Encrypt X1 (RSA cross-signed, broad compatibility) and X2 (ECDSA-only)
+    /// chains, selecting per-client based on advertised signature schemes.
+    pub fn letsencrypt_x1_x2() -> Self {
+        Self::DualChain("ISRG Root X2".into())
+    }
+}
+
 /// Configuration for an ACME resolver.
 ///
 /// The type parameters represent the error types for the certificate cache and account cache.
@@ -21,6 +58,7 @@ pub struct AcmeConfig<EC: Debug, EA: Debug = EC> {
     pub(crate) contact: Vec<String>,
     pub(crate) cache: Box<dyn Cache<EC = EC, EA = EA>>,
     pub(crate) eab: Option<ExternalAccountKey>,
+    pub(crate) cert_chain: CertChainPreference,
 }
 
 impl AcmeConfig<Infallible, Infallible> {
@@ -79,6 +117,7 @@ impl AcmeConfig<Infallible, Infallible> {
             contact: vec![],
             cache: Box::new(NoCache::new()),
             eab: None,
+            cert_chain: CertChainPreference::Default,
         }
     }
 }
@@ -131,6 +170,11 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeConfig<EC, EA> {
         self
     }
 
+    /// Set the certificate chain preference. See [`CertChainPreference`] for details.
+    pub fn cert_chain(mut self, preference: CertChainPreference) -> Self {
+        self.cert_chain = preference;
+        self
+    }
     pub fn cache<C: 'static + Cache>(self, cache: C) -> AcmeConfig<C::EC, C::EA> {
         AcmeConfig {
             client_config: self.client_config,
@@ -139,6 +183,7 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeConfig<EC, EA> {
             contact: self.contact,
             cache: Box::new(cache),
             eab: self.eab,
+            cert_chain: self.cert_chain,
         }
     }
     pub fn cache_compose<CC: 'static + CertCache, CA: 'static + AccountCache>(

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -99,3 +99,160 @@ impl ResolvesServerCert for ResolvesServerCertAcme {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::caches::TestCache;
+    use crate::CertCache;
+    use rustls::crypto::ring::sign::any_ecdsa_type;
+    use rustls::pki_types::{CertificateDer, PrivateKeyDer, PrivatePkcs8KeyDer, ServerName};
+    use std::convert::{Infallible, TryFrom};
+
+    /// Parse TestCache PEM output into a CertifiedKey + cert chain DER.
+    async fn make_cert(
+        cache: &TestCache<Infallible, Infallible>,
+    ) -> (Arc<CertifiedKey>, Vec<CertificateDer<'static>>) {
+        let pem_bytes = cache
+            .load_cert(
+                &["test.example.com".to_string()],
+                "",
+                crate::CertChainKind::Default,
+            )
+            .await
+            .unwrap()
+            .unwrap();
+        let mut pems = pem::parse_many(&pem_bytes).unwrap();
+        let pk_bytes = pems.remove(0).into_contents();
+        let pk_der: PrivatePkcs8KeyDer = pk_bytes.into();
+        let pk: PrivateKeyDer = pk_der.into();
+        let pk = any_ecdsa_type(&pk).unwrap();
+        let cert_chain: Vec<CertificateDer<'static>> = pems
+            .into_iter()
+            .map(|p| CertificateDer::from(p.into_contents()))
+            .collect();
+        let key = Arc::new(CertifiedKey::new(cert_chain.clone(), pk));
+        (key, cert_chain)
+    }
+
+    fn make_root_store(ca_pem: &str) -> rustls::RootCertStore {
+        let ca_pems = pem::parse_many(ca_pem).unwrap();
+        let mut root_store = rustls::RootCertStore::empty();
+        for p in ca_pems {
+            root_store
+                .add(CertificateDer::from(p.into_contents()))
+                .unwrap();
+        }
+        root_store
+    }
+
+    /// Helper: do an in-process TLS handshake and return the peer certs served.
+    async fn do_handshake(
+        resolver: Arc<ResolvesServerCertAcme>,
+        root_store: rustls::RootCertStore,
+    ) -> Vec<CertificateDer<'static>> {
+        let server_config = Arc::new(
+            rustls::ServerConfig::builder()
+                .with_no_client_auth()
+                .with_cert_resolver(resolver),
+        );
+        let acceptor = tokio_rustls::TlsAcceptor::from(server_config);
+
+        let client_config = Arc::new(
+            rustls::ClientConfig::builder()
+                .with_root_certificates(root_store)
+                .with_no_client_auth(),
+        );
+        let connector = tokio_rustls::TlsConnector::from(client_config);
+
+        let (client_io, server_io) = tokio::io::duplex(4096);
+        let server_name = ServerName::try_from("test.example.com")
+            .unwrap()
+            .to_owned();
+
+        let (client_result, server_result) = tokio::join!(
+            connector.connect(server_name, client_io),
+            acceptor.accept(server_io),
+        );
+
+        let _ = server_result.expect("TLS server handshake failed");
+        let client_tls = client_result.expect("TLS client handshake failed");
+        let (_, conn) = client_tls.get_ref();
+        conn.peer_certificates().unwrap().to_vec()
+    }
+
+    /// When the client doesn't support the primary chain's signature schemes,
+    /// the resolver should fall back to the alternate chain.
+    ///
+    /// We simulate this by setting the primary's required_schemes to ED448,
+    /// which ring-based clients don't advertise support for.
+    #[tokio::test]
+    async fn dual_chain_fallback_to_alt() {
+        let cache = TestCache::<Infallible, Infallible>::new();
+        let (primary_key, _) = make_cert(&cache).await;
+        let (alt_key, alt_chain) = make_cert(&cache).await;
+
+        let resolver = ResolvesServerCertAcme::new();
+        // Primary requires ED448 (not supported by ring clients).
+        resolver.set_cert(primary_key, vec![SignatureScheme::ED448]);
+        // Alt requires ECDSA P-256 (supported by ring clients).
+        resolver.set_alt_cert(Some((
+            alt_key,
+            vec![SignatureScheme::ECDSA_NISTP256_SHA256],
+        )));
+
+        let root_store = make_root_store(cache.ca_pem());
+        let peer_certs = do_handshake(resolver, root_store).await;
+
+        assert_eq!(
+            peer_certs[0], alt_chain[0],
+            "should serve alt cert when client doesn't support primary's schemes"
+        );
+    }
+
+    /// When the client supports the primary chain's signature schemes,
+    /// the resolver should serve the primary chain even if alt is available.
+    #[tokio::test]
+    async fn dual_chain_serves_primary_when_supported() {
+        let cache = TestCache::<Infallible, Infallible>::new();
+        let (primary_key, primary_chain) = make_cert(&cache).await;
+        let (alt_key, _) = make_cert(&cache).await;
+
+        let resolver = ResolvesServerCertAcme::new();
+        // Primary requires ECDSA P-256 (supported by ring clients).
+        resolver.set_cert(
+            primary_key,
+            vec![SignatureScheme::ECDSA_NISTP256_SHA256],
+        );
+        resolver.set_alt_cert(Some((
+            alt_key,
+            vec![SignatureScheme::ECDSA_NISTP256_SHA256],
+        )));
+
+        let root_store = make_root_store(cache.ca_pem());
+        let peer_certs = do_handshake(resolver, root_store).await;
+
+        assert_eq!(
+            peer_certs[0], primary_chain[0],
+            "should serve primary cert when client supports its schemes"
+        );
+    }
+
+    /// Without DualChain (no alt cert set), the primary is always served.
+    #[tokio::test]
+    async fn single_chain_serves_primary() {
+        let cache = TestCache::<Infallible, Infallible>::new();
+        let (primary_key, primary_chain) = make_cert(&cache).await;
+
+        let resolver = ResolvesServerCertAcme::new();
+        resolver.set_cert(
+            primary_key,
+            vec![SignatureScheme::ECDSA_NISTP256_SHA256],
+        );
+
+        let root_store = make_root_store(cache.ca_pem());
+        let peer_certs = do_handshake(resolver, root_store).await;
+
+        assert_eq!(peer_certs[0], primary_chain[0]);
+    }
+}

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -166,9 +166,7 @@ mod tests {
         let connector = tokio_rustls::TlsConnector::from(client_config);
 
         let (client_io, server_io) = tokio::io::duplex(4096);
-        let server_name = ServerName::try_from("test.example.com")
-            .unwrap()
-            .to_owned();
+        let server_name = ServerName::try_from("test.example.com").unwrap().to_owned();
 
         let (client_result, server_result) = tokio::join!(
             connector.connect(server_name, client_io),
@@ -220,10 +218,7 @@ mod tests {
 
         let resolver = ResolvesServerCertAcme::new();
         // Primary requires ECDSA P-256 (supported by ring clients).
-        resolver.set_cert(
-            primary_key,
-            vec![SignatureScheme::ECDSA_NISTP256_SHA256],
-        );
+        resolver.set_cert(primary_key, vec![SignatureScheme::ECDSA_NISTP256_SHA256]);
         resolver.set_alt_cert(Some((
             alt_key,
             vec![SignatureScheme::ECDSA_NISTP256_SHA256],
@@ -245,10 +240,7 @@ mod tests {
         let (primary_key, primary_chain) = make_cert(&cache).await;
 
         let resolver = ResolvesServerCertAcme::new();
-        resolver.set_cert(
-            primary_key,
-            vec![SignatureScheme::ECDSA_NISTP256_SHA256],
-        );
+        resolver.set_cert(primary_key, vec![SignatureScheme::ECDSA_NISTP256_SHA256]);
 
         let root_store = make_root_store(cache.ca_pem());
         let peer_certs = do_handshake(resolver, root_store).await;

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -37,25 +37,16 @@ impl ResolvesServerCertAcme {
             }),
         })
     }
-    pub(crate) fn set_cert(
-        &self,
-        cert: Arc<CertifiedKey>,
-        required_schemes: Vec<SignatureScheme>,
-    ) {
+    pub(crate) fn set_cert(&self, cert: Arc<CertifiedKey>, required_schemes: Vec<SignatureScheme>) {
         self.inner.lock().unwrap().cert = Some(CertWithSchemes {
             key: cert,
             required_schemes,
         });
     }
-    pub(crate) fn set_alt_cert(
-        &self,
-        cert: Option<(Arc<CertifiedKey>, Vec<SignatureScheme>)>,
-    ) {
-        self.inner.lock().unwrap().alt_cert = cert.map(|(key, required_schemes)| {
-            CertWithSchemes {
-                key,
-                required_schemes,
-            }
+    pub(crate) fn set_alt_cert(&self, cert: Option<(Arc<CertifiedKey>, Vec<SignatureScheme>)>) {
+        self.inner.lock().unwrap().alt_cert = cert.map(|(key, required_schemes)| CertWithSchemes {
+            key,
+            required_schemes,
         });
     }
     pub(crate) fn set_auth_key(&self, domain: String, cert: Arc<CertifiedKey>) {

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -12,11 +12,18 @@ pub struct ResolvesServerCertAcme {
 }
 
 #[derive(Debug)]
+struct CertWithSchemes {
+    key: Arc<CertifiedKey>,
+    /// Signature schemes required to verify this certificate chain.
+    required_schemes: Vec<SignatureScheme>,
+}
+
+#[derive(Debug)]
 struct Inner {
-    cert: Option<Arc<CertifiedKey>>,
-    /// Alternate certificate chain for DualChain mode. When set, clients that advertise
-    /// no RSA signature schemes receive this chain instead of the primary.
-    alt_cert: Option<Arc<CertifiedKey>>,
+    cert: Option<CertWithSchemes>,
+    /// Alternate certificate chain for DualChain mode. Served to clients that
+    /// cannot verify the primary chain but can verify this one.
+    alt_cert: Option<CertWithSchemes>,
     auth_keys: BTreeMap<String, Arc<CertifiedKey>>,
 }
 
@@ -30,31 +37,30 @@ impl ResolvesServerCertAcme {
             }),
         })
     }
-    pub(crate) fn set_cert(&self, cert: Arc<CertifiedKey>) {
-        self.inner.lock().unwrap().cert = Some(cert);
+    pub(crate) fn set_cert(
+        &self,
+        cert: Arc<CertifiedKey>,
+        required_schemes: Vec<SignatureScheme>,
+    ) {
+        self.inner.lock().unwrap().cert = Some(CertWithSchemes {
+            key: cert,
+            required_schemes,
+        });
     }
-    pub(crate) fn set_alt_cert(&self, cert: Option<Arc<CertifiedKey>>) {
-        self.inner.lock().unwrap().alt_cert = cert;
+    pub(crate) fn set_alt_cert(
+        &self,
+        cert: Option<(Arc<CertifiedKey>, Vec<SignatureScheme>)>,
+    ) {
+        self.inner.lock().unwrap().alt_cert = cert.map(|(key, required_schemes)| {
+            CertWithSchemes {
+                key,
+                required_schemes,
+            }
+        });
     }
     pub(crate) fn set_auth_key(&self, domain: String, cert: Arc<CertifiedKey>) {
         self.inner.lock().unwrap().auth_keys.insert(domain, cert);
     }
-}
-
-/// Returns true if the client's signature schemes include any RSA-based scheme.
-fn client_supports_rsa(client_hello: &ClientHello) -> bool {
-    client_hello.signature_schemes().iter().any(|s| {
-        matches!(
-            s,
-            SignatureScheme::RSA_PKCS1_SHA256
-                | SignatureScheme::RSA_PKCS1_SHA384
-                | SignatureScheme::RSA_PKCS1_SHA512
-                | SignatureScheme::RSA_PSS_SHA256
-                | SignatureScheme::RSA_PSS_SHA384
-                | SignatureScheme::RSA_PSS_SHA512
-                | SignatureScheme::RSA_PKCS1_SHA1
-        )
-    })
 }
 
 impl ResolvesServerCert for ResolvesServerCertAcme {
@@ -78,14 +84,27 @@ impl ResolvesServerCert for ResolvesServerCertAcme {
             }
         } else {
             let inner = self.inner.lock().unwrap();
-            // In DualChain mode: serve the alternate (e.g. ECDSA-only) chain to clients
-            // that don't support RSA, and the default (e.g. RSA cross-signed) chain otherwise.
-            if let Some(alt_cert) = &inner.alt_cert {
-                if !client_supports_rsa(&client_hello) {
-                    return Some(alt_cert.clone());
+            let client_schemes = client_hello.signature_schemes();
+
+            // In DualChain mode: if the client can't verify the primary chain
+            // but can verify the alternate, serve the alternate.
+            if let (Some(primary), Some(alt)) = (&inner.cert, &inner.alt_cert) {
+                let supports_primary = primary
+                    .required_schemes
+                    .iter()
+                    .any(|s| client_schemes.contains(s));
+                if !supports_primary {
+                    let supports_alt = alt
+                        .required_schemes
+                        .iter()
+                        .any(|s| client_schemes.contains(s));
+                    if supports_alt {
+                        return Some(alt.key.clone());
+                    }
                 }
             }
-            inner.cert.clone()
+
+            inner.cert.as_ref().map(|c| c.key.clone())
         }
     }
 }

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -1,6 +1,7 @@
 use crate::acme::ACME_TLS_ALPN_NAME;
 use rustls::server::{ClientHello, ResolvesServerCert};
 use rustls::sign::CertifiedKey;
+use rustls::SignatureScheme;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::sync::Mutex;
@@ -13,6 +14,9 @@ pub struct ResolvesServerCertAcme {
 #[derive(Debug)]
 struct Inner {
     cert: Option<Arc<CertifiedKey>>,
+    /// Alternate certificate chain for DualChain mode. When set, clients that advertise
+    /// no RSA signature schemes receive this chain instead of the primary.
+    alt_cert: Option<Arc<CertifiedKey>>,
     auth_keys: BTreeMap<String, Arc<CertifiedKey>>,
 }
 
@@ -21,6 +25,7 @@ impl ResolvesServerCertAcme {
         Arc::new(Self {
             inner: Mutex::new(Inner {
                 cert: None,
+                alt_cert: None,
                 auth_keys: Default::default(),
             }),
         })
@@ -28,9 +33,28 @@ impl ResolvesServerCertAcme {
     pub(crate) fn set_cert(&self, cert: Arc<CertifiedKey>) {
         self.inner.lock().unwrap().cert = Some(cert);
     }
+    pub(crate) fn set_alt_cert(&self, cert: Option<Arc<CertifiedKey>>) {
+        self.inner.lock().unwrap().alt_cert = cert;
+    }
     pub(crate) fn set_auth_key(&self, domain: String, cert: Arc<CertifiedKey>) {
         self.inner.lock().unwrap().auth_keys.insert(domain, cert);
     }
+}
+
+/// Returns true if the client's signature schemes include any RSA-based scheme.
+fn client_supports_rsa(client_hello: &ClientHello) -> bool {
+    client_hello.signature_schemes().iter().any(|s| {
+        matches!(
+            s,
+            SignatureScheme::RSA_PKCS1_SHA256
+                | SignatureScheme::RSA_PKCS1_SHA384
+                | SignatureScheme::RSA_PKCS1_SHA512
+                | SignatureScheme::RSA_PSS_SHA256
+                | SignatureScheme::RSA_PSS_SHA384
+                | SignatureScheme::RSA_PSS_SHA512
+                | SignatureScheme::RSA_PKCS1_SHA1
+        )
+    })
 }
 
 impl ResolvesServerCert for ResolvesServerCertAcme {
@@ -53,7 +77,15 @@ impl ResolvesServerCert for ResolvesServerCertAcme {
                 }
             }
         } else {
-            self.inner.lock().unwrap().cert.clone()
+            let inner = self.inner.lock().unwrap();
+            // In DualChain mode: serve the alternate (e.g. ECDSA-only) chain to clients
+            // that don't support RSA, and the default (e.g. RSA cross-signed) chain otherwise.
+            if let Some(alt_cert) = &inner.alt_cert {
+                if !client_supports_rsa(&client_hello) {
+                    return Some(alt_cert.clone());
+                }
+            }
+            inner.cert.clone()
         }
     }
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -23,6 +23,7 @@ use crate::acceptor::AcmeAcceptor;
 use crate::acme::{
     Account, AcmeError, Auth, AuthStatus, Directory, Identifier, Order, OrderStatus,
 };
+use crate::config::CertChainPreference;
 use crate::{AcmeConfig, Incoming, ResolvesServerCertAcme};
 
 type Timer = std::pin::Pin<Box<Sleep>>;
@@ -40,8 +41,9 @@ pub struct AcmeState<EC: Debug = Infallible, EA: Debug = EC> {
 
     early_action: Option<BoxFuture<Event<EC, EA>>>,
     load_cert: Option<BoxFuture<Result<Option<Vec<u8>>, EC>>>,
+    load_alt_cert: Option<BoxFuture<Result<Option<Vec<u8>>, EC>>>,
     load_account: Option<BoxFuture<Result<Option<Vec<u8>>, EA>>>,
-    order: Option<BoxFuture<Result<Vec<u8>, OrderError>>>,
+    order: Option<BoxFuture<Result<OrderResult, OrderError>>>,
     backoff_cnt: usize,
     wait: Option<Timer>,
 }
@@ -102,6 +104,30 @@ pub enum CertParseError {
     InvalidPrivateKey,
 }
 
+struct OrderResult {
+    primary: Vec<u8>,
+    alternate: Option<Vec<u8>>,
+}
+
+/// Extract the subject common name of the last certificate (root) in a PEM chain.
+/// The input should be a PEM string containing only certificates (no private key).
+fn chain_root_issuer(cert_pem: &str) -> Option<String> {
+    let pems = pem::parse_many(cert_pem).ok()?;
+    let last_der: Vec<u8> = pems.last()?.contents().to_vec();
+    extract_subject_cn(&last_der)
+}
+
+fn extract_subject_cn(der: &[u8]) -> Option<String> {
+    let (_, cert) = parse_x509_certificate(der).ok()?;
+    let result = cert
+        .subject()
+        .iter_common_name()
+        .next()
+        .and_then(|cn| cn.as_str().ok())
+        .map(|s| s.to_string());
+    result
+}
+
 impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
     pub fn incoming<
         TCP: AsyncRead + AsyncWrite + Unpin,
@@ -156,6 +182,15 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
                     config
                         .cache
                         .load_cert(&config.domains, &config.directory_url)
+                        .await
+                }
+            })),
+            load_alt_cert: Some(Box::pin({
+                let config = config.clone();
+                async move {
+                    config
+                        .cache
+                        .load_alt_cert(&config.domains, &config.directory_url)
                         .await
                 }
             })),
@@ -236,7 +271,7 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
         config: Arc<AcmeConfig<EC, EA>>,
         resolver: Arc<ResolvesServerCertAcme>,
         key_pair: Vec<u8>,
-    ) -> Result<Vec<u8>, OrderError> {
+    ) -> Result<OrderResult, OrderError> {
         let directory = Directory::discover(&config.client_config, &config.directory_url).await?;
         let account = Account::create_with_keypair(
             &config.client_config,
@@ -287,19 +322,121 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
                 }
                 OrderStatus::Valid { certificate } => {
                     log::info!("download certificate");
-                    let pem = [
-                        &key_pair.serialize_pem(),
-                        "\n",
-                        &account
-                            .certificate(&config.client_config, certificate)
-                            .await?,
-                    ]
-                    .concat();
-                    return Ok(pem.into_bytes());
+                    let cert_response = account
+                        .certificate(&config.client_config, &certificate)
+                        .await?;
+                    let key_pem = key_pair.serialize_pem();
+
+                    let primary_pem =
+                        [&key_pem, "\n", &cert_response.pem].concat();
+
+                    let alternate = match &config.cert_chain {
+                        CertChainPreference::Default => None,
+                        CertChainPreference::PreferredChain(issuer) => {
+                            Self::select_preferred_chain(
+                                &account,
+                                &config.client_config,
+                                &cert_response.pem,
+                                &cert_response.alternate_urls,
+                                issuer,
+                                &key_pem,
+                            )
+                            .await?
+                        }
+                        CertChainPreference::DualChain(issuer) => {
+                            Self::find_alternate_chain(
+                                &account,
+                                &config.client_config,
+                                &cert_response.pem,
+                                &cert_response.alternate_urls,
+                                issuer,
+                                &key_pem,
+                            )
+                            .await?
+                        }
+                    };
+
+                    // For PreferredChain, if we found a match, use it as primary.
+                    let primary = match &config.cert_chain {
+                        CertChainPreference::PreferredChain(_) if alternate.is_some() => {
+                            alternate.clone().unwrap()
+                        }
+                        _ => primary_pem.into_bytes(),
+                    };
+
+                    // For PreferredChain, alternate is used as primary so clear it.
+                    let alternate = match &config.cert_chain {
+                        CertChainPreference::PreferredChain(_) => None,
+                        _ => alternate,
+                    };
+
+                    return Ok(OrderResult {
+                        primary,
+                        alternate,
+                    });
                 }
                 OrderStatus::Invalid => return Err(OrderError::BadOrder(order)),
             }
         }
+    }
+    /// Find an alternate chain matching the given issuer CN and return it as PEM bytes
+    /// (key + chain). Returns `None` if no match is found.
+    async fn find_alternate_chain(
+        account: &Account,
+        client_config: &Arc<rustls::ClientConfig>,
+        default_cert_pem: &str,
+        alternate_urls: &[String],
+        target_issuer: &str,
+        key_pem: &str,
+    ) -> Result<Option<Vec<u8>>, AcmeError> {
+        // Check if the default chain already matches.
+        if let Some(issuer) = chain_root_issuer(default_cert_pem) {
+            if issuer == target_issuer {
+                log::info!("default chain already matches preferred issuer '{target_issuer}'");
+                return Ok(Some([key_pem, "\n", default_cert_pem].concat().into_bytes()));
+            }
+        }
+        // Try each alternate chain URL.
+        for url in alternate_urls {
+            log::info!("fetching alternate chain from {url}");
+            let alt_pem = account.certificate_from_url(client_config, url).await?;
+            if let Some(issuer) = chain_root_issuer(&alt_pem) {
+                log::info!("alternate chain root issuer: '{issuer}'");
+                if issuer == target_issuer {
+                    return Ok(Some([key_pem, "\n", &alt_pem].concat().into_bytes()));
+                }
+            }
+        }
+        log::warn!(
+            "no alternate chain found matching issuer '{target_issuer}', using default chain"
+        );
+        Ok(None)
+    }
+    /// For PreferredChain: find matching alternate, or None to keep default.
+    async fn select_preferred_chain(
+        account: &Account,
+        client_config: &Arc<rustls::ClientConfig>,
+        default_cert_pem: &str,
+        alternate_urls: &[String],
+        target_issuer: &str,
+        key_pem: &str,
+    ) -> Result<Option<Vec<u8>>, AcmeError> {
+        // If default already matches, no need to search alternates.
+        if let Some(issuer) = chain_root_issuer(default_cert_pem) {
+            if issuer == target_issuer {
+                log::info!("default chain matches preferred issuer '{target_issuer}'");
+                return Ok(None);
+            }
+        }
+        Self::find_alternate_chain(
+            account,
+            client_config,
+            default_cert_pem,
+            alternate_urls,
+            target_issuer,
+            key_pem,
+        )
+        .await
     }
     async fn authorize(
         config: &AcmeConfig<EC, EA>,
@@ -367,6 +504,28 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
                 }
             }
 
+            // load alt cert from cache (for DualChain mode)
+            if let Some(load_alt_cert) = &mut self.load_alt_cert {
+                let result = ready!(load_alt_cert.poll_unpin(cx));
+                self.load_alt_cert.take();
+                match result {
+                    Ok(Some(pem)) => {
+                        match Self::parse_cert(&pem) {
+                            Ok((alt_cert, _)) => {
+                                self.resolver.set_alt_cert(Some(Arc::new(alt_cert)));
+                            }
+                            Err(err) => {
+                                log::warn!("failed to parse cached alternate cert: {err}");
+                            }
+                        }
+                    }
+                    Ok(None) => {}
+                    Err(err) => {
+                        log::warn!("failed to load cached alternate cert: {err:?}");
+                    }
+                }
+            }
+
             // load from account cache
             if let Some(load_account) = &mut self.load_account {
                 let result = ready!(load_account.poll_unpin(cx));
@@ -383,9 +542,46 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
                 let result = ready!(order.poll_unpin(cx));
                 self.order.take();
                 match result {
-                    Ok(pem) => {
+                    Ok(order_result) => {
                         self.backoff_cnt = 0;
-                        return Poll::Ready(Self::process_cert(self.get_mut(), pem, false));
+                        // Set alternate cert if present (DualChain mode).
+                        let alt_pem_for_cache = if let Some(alt_pem) = &order_result.alternate {
+                            match Self::parse_cert(alt_pem) {
+                                Ok((alt_cert, _)) => {
+                                    self.resolver.set_alt_cert(Some(Arc::new(alt_cert)));
+                                    Some(alt_pem.clone())
+                                }
+                                Err(err) => {
+                                    log::warn!("failed to parse alternate cert chain: {err}");
+                                    None
+                                }
+                            }
+                        } else {
+                            self.resolver.set_alt_cert(None);
+                            None
+                        };
+                        // Store alt cert in cache (fire-and-forget via early_action chain).
+                        if let Some(alt_pem) = alt_pem_for_cache {
+                            let config = self.config.clone();
+                            tokio::spawn(async move {
+                                if let Err(err) = config
+                                    .cache
+                                    .store_alt_cert(
+                                        &config.domains,
+                                        &config.directory_url,
+                                        &alt_pem,
+                                    )
+                                    .await
+                                {
+                                    log::warn!("failed to cache alternate cert: {err:?}");
+                                }
+                            });
+                        }
+                        return Poll::Ready(Self::process_cert(
+                            self.get_mut(),
+                            order_result.primary,
+                            false,
+                        ));
                     }
                     Err(err) => {
                         // TODO: replace key on some errors or high backoff_cnt?

--- a/src/state.rs
+++ b/src/state.rs
@@ -258,9 +258,10 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
 
         let mut validity = None;
         let mut required_schemes = Vec::new();
-        for (i, der) in cert_chain.iter().enumerate() {
+
+        for der in cert_chain.iter() {
             let (_, cert) = parse_x509_certificate(der.as_ref()).map_err(CertParseError::X509)?;
-            if i == 0 {
+            if validity.is_none() {
                 let v = cert.validity();
                 validity = Some(
                     [v.not_before, v.not_after]
@@ -274,8 +275,9 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
             }
         }
 
+        let validity = validity.expect("length checked above");
         let cert = CertifiedKey::new(cert_chain, pk);
-        Ok((cert, validity.unwrap(), required_schemes))
+        Ok((cert, validity, required_schemes))
     }
 
     #[allow(clippy::result_large_err)]
@@ -436,7 +438,7 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
     ) -> Result<Option<String>, AcmeError> {
         for url in alternate_urls {
             log::info!("fetching alternate chain from {url}");
-            let alt_pem = account.certificate_from_url(client_config, url).await?;
+            let alt_pem = account.certificate(client_config, url).await?;
             if let Some(issuer) = chain_root_issuer(&alt_pem) {
                 log::info!("alternate chain root issuer: '{issuer}'");
                 if issuer == target_issuer {

--- a/src/state.rs
+++ b/src/state.rs
@@ -437,10 +437,10 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
         target_issuer: &str,
     ) -> Result<Option<String>, AcmeError> {
         for url in alternate_urls {
-            log::info!("fetching alternate chain from {url}");
+            log::debug!("fetching alternate chain from {url}");
             let alt_pem = account.certificate(client_config, url).await?;
             if let Some(issuer) = chain_root_issuer(&alt_pem) {
-                log::info!("alternate chain root issuer: '{issuer}'");
+                log::debug!("alternate chain root issuer: '{issuer}'");
                 if issuer == target_issuer {
                     return Ok(Some(alt_pem));
                 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -13,7 +13,7 @@ use rcgen::{CertificateParams, DistinguishedName, Error as RcgenError, PKCS_ECDS
 use rustls::crypto::ring::sign::any_ecdsa_type;
 use rustls::pki_types::{CertificateDer as RustlsCertificate, PrivateKeyDer, PrivatePkcs8KeyDer};
 use rustls::sign::CertifiedKey;
-use rustls::ServerConfig;
+use rustls::{ServerConfig, SignatureScheme};
 use thiserror::Error;
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::time::Sleep;
@@ -124,6 +124,33 @@ fn chain_root_issuer(cert_pem: &str) -> Option<String> {
     cn
 }
 
+/// Map an X.509 signature algorithm OID to the corresponding rustls SignatureScheme.
+fn sig_oid_to_scheme(oid: &x509_parser::asn1_rs::Oid) -> Option<SignatureScheme> {
+    use x509_parser::oid_registry::*;
+
+    if *oid == OID_PKCS1_SHA256WITHRSA {
+        Some(SignatureScheme::RSA_PKCS1_SHA256)
+    } else if *oid == OID_PKCS1_SHA384WITHRSA {
+        Some(SignatureScheme::RSA_PKCS1_SHA384)
+    } else if *oid == OID_PKCS1_SHA512WITHRSA {
+        Some(SignatureScheme::RSA_PKCS1_SHA512)
+    } else if *oid == OID_PKCS1_RSASSAPSS {
+        Some(SignatureScheme::RSA_PSS_SHA256)
+    } else if *oid == OID_SIG_ECDSA_WITH_SHA256 {
+        Some(SignatureScheme::ECDSA_NISTP256_SHA256)
+    } else if *oid == OID_SIG_ECDSA_WITH_SHA384 {
+        Some(SignatureScheme::ECDSA_NISTP384_SHA384)
+    } else if *oid == OID_SIG_ECDSA_WITH_SHA512 {
+        Some(SignatureScheme::ECDSA_NISTP521_SHA512)
+    } else if *oid == OID_SIG_ED25519 {
+        Some(SignatureScheme::ED25519)
+    } else if *oid == OID_SIG_ED448 {
+        Some(SignatureScheme::ED448)
+    } else {
+        None
+    }
+}
+
 impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
     pub fn incoming<
         TCP: AsyncRead + AsyncWrite + Unpin,
@@ -212,7 +239,9 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
             wait: None,
         }
     }
-    fn parse_cert(pem: &[u8]) -> Result<(CertifiedKey, [DateTime<Utc>; 2]), CertParseError> {
+    fn parse_cert(
+        pem: &[u8],
+    ) -> Result<(CertifiedKey, [DateTime<Utc>; 2], Vec<SignatureScheme>), CertParseError> {
         let mut pems = pem::parse_many(pem)?;
         if pems.len() < 2 {
             return Err(CertParseError::TooFewPem(pems.len()));
@@ -226,21 +255,33 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
         };
         let cert_chain: Vec<RustlsCertificate> =
             pems.into_iter().map(|p| p.into_contents().into()).collect();
-        let validity = match parse_x509_certificate(cert_chain[0].as_ref()) {
-            Ok((_, cert)) => {
-                let validity = cert.validity();
-                [validity.not_before, validity.not_after]
-                    .map(|t| Utc.timestamp_opt(t.timestamp(), 0).earliest().unwrap())
+
+        let mut validity = None;
+        let mut required_schemes = Vec::new();
+        for (i, der) in cert_chain.iter().enumerate() {
+            let (_, cert) = parse_x509_certificate(der.as_ref())
+                .map_err(CertParseError::X509)?;
+            if i == 0 {
+                let v = cert.validity();
+                validity = Some(
+                    [v.not_before, v.not_after]
+                        .map(|t| Utc.timestamp_opt(t.timestamp(), 0).earliest().unwrap()),
+                );
             }
-            Err(err) => return Err(CertParseError::X509(err)),
-        };
+            if let Some(scheme) = sig_oid_to_scheme(&cert.signature_algorithm.algorithm) {
+                if !required_schemes.contains(&scheme) {
+                    required_schemes.push(scheme);
+                }
+            }
+        }
+
         let cert = CertifiedKey::new(cert_chain, pk);
-        Ok((cert, validity))
+        Ok((cert, validity.unwrap(), required_schemes))
     }
 
     #[allow(clippy::result_large_err)]
     fn process_cert(&mut self, pem: Vec<u8>, cached: bool) -> Event<EC, EA> {
-        let (cert, validity) = match (Self::parse_cert(&pem), cached) {
+        let (cert, validity, schemes) = match (Self::parse_cert(&pem), cached) {
             (Ok(r), _) => r,
             (Err(err), cached) => {
                 return match cached {
@@ -249,7 +290,7 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
                 }
             }
         };
-        self.resolver.set_cert(Arc::new(cert));
+        self.resolver.set_cert(Arc::new(cert), schemes);
         let wait_duration = (validity[1] - (validity[1] - validity[0]) / 3 - Utc::now())
             .max(chrono::Duration::zero())
             .to_std()
@@ -366,7 +407,7 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
                         }
 
                         // Serve two chains: the default as primary, and an alternate
-                        // matching `issuer` for clients that don't support RSA.
+                        // matching `issuer` for clients whose signature schemes differ.
                         CertChainPreference::DualChain(issuer) => {
                             let alternate = Self::fetch_chain_by_issuer(
                                 &account,
@@ -481,8 +522,9 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
                 self.load_alt_cert.take();
                 match result {
                     Ok(Some(pem)) => match Self::parse_cert(&pem) {
-                        Ok((alt_cert, _)) => {
-                            self.resolver.set_alt_cert(Some(Arc::new(alt_cert)));
+                        Ok((alt_cert, _, schemes)) => {
+                            self.resolver
+                                .set_alt_cert(Some((Arc::new(alt_cert), schemes)));
                         }
                         Err(err) => {
                             log::warn!("failed to parse cached alternate cert: {err}");
@@ -516,8 +558,9 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
                         // Set alternate cert if present (DualChain mode).
                         if let Some(alt_pem) = &order_result.alternate {
                             match Self::parse_cert(alt_pem) {
-                                Ok((alt_cert, _)) => {
-                                    self.resolver.set_alt_cert(Some(Arc::new(alt_cert)));
+                                Ok((alt_cert, _, schemes)) => {
+                                    self.resolver
+                                        .set_alt_cert(Some((Arc::new(alt_cert), schemes)));
                                     // Store alt cert in cache.
                                     let alt_pem = alt_pem.clone();
                                     let config = self.config.clone();

--- a/src/state.rs
+++ b/src/state.rs
@@ -336,42 +336,47 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
                         .await?;
                     let key_pem = key_pair.serialize_pem();
 
+                    // Build key+cert PEM bundle(s) based on chain preference.
+                    let make_pem = |cert_pem: &str| -> Vec<u8> {
+                        [&key_pem, "\n", cert_pem].concat().into_bytes()
+                    };
+
                     let (primary, alternate) = match &config.cert_chain {
-                        CertChainPreference::Default => {
-                            let pem = [&key_pem, "\n", &cert_response.pem].concat().into_bytes();
-                            (pem, None)
-                        }
+                        // Use the default chain as-is.
+                        CertChainPreference::Default => (make_pem(&cert_response.pem), None),
+
+                        // Use a single chain: prefer an alternate matching `issuer`,
+                        // fall back to the default if not found.
                         CertChainPreference::PreferredChain(issuer) => {
-                            let cert_pem =
-                                if chain_root_issuer(&cert_response.pem).as_deref() == Some(issuer)
-                                {
-                                    None
-                                } else {
-                                    Self::fetch_chain_by_issuer(
-                                        &account,
-                                        &config.client_config,
-                                        &cert_response.alternate_urls,
-                                        issuer,
-                                    )
-                                    .await?
-                                };
-                            let cert_pem = cert_pem.as_deref().unwrap_or(&cert_response.pem);
-                            let pem = [&key_pem, "\n", cert_pem].concat().into_bytes();
-                            (pem, None)
+                            let default_matches =
+                                chain_root_issuer(&cert_response.pem).as_deref() == Some(issuer);
+                            let pem = if default_matches {
+                                cert_response.pem
+                            } else {
+                                Self::fetch_chain_by_issuer(
+                                    &account,
+                                    &config.client_config,
+                                    &cert_response.alternate_urls,
+                                    issuer,
+                                )
+                                .await?
+                                .unwrap_or(cert_response.pem)
+                            };
+                            (make_pem(&pem), None)
                         }
+
+                        // Serve two chains: the default as primary, and an alternate
+                        // matching `issuer` for clients that don't support RSA.
                         CertChainPreference::DualChain(issuer) => {
-                            let primary =
-                                [&key_pem, "\n", &cert_response.pem].concat().into_bytes();
-                            let alt = Self::fetch_chain_by_issuer(
+                            let alternate = Self::fetch_chain_by_issuer(
                                 &account,
                                 &config.client_config,
                                 &cert_response.alternate_urls,
                                 issuer,
                             )
-                            .await?;
-                            let alternate = alt
-                                .map(|pem| [&key_pem, "\n", &pem].concat().into_bytes());
-                            (primary, alternate)
+                            .await?
+                            .map(|pem| make_pem(&pem));
+                            (make_pem(&cert_response.pem), alternate)
                         }
                     };
 

--- a/src/state.rs
+++ b/src/state.rs
@@ -19,6 +19,12 @@ use tokio::io::{AsyncRead, AsyncWrite};
 use tokio::time::Sleep;
 use x509_parser::parse_x509_certificate;
 
+struct ParsedCert {
+    certified_key: CertifiedKey,
+    validity: [DateTime<Utc>; 2],
+    signature_schemes: Vec<SignatureScheme>,
+}
+
 use crate::acceptor::AcmeAcceptor;
 use crate::acme::{
     Account, AcmeError, Auth, AuthStatus, Directory, Identifier, Order, OrderStatus,
@@ -239,9 +245,7 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
             wait: None,
         }
     }
-    fn parse_cert(
-        pem: &[u8],
-    ) -> Result<(CertifiedKey, [DateTime<Utc>; 2], Vec<SignatureScheme>), CertParseError> {
+    fn parse_cert(pem: &[u8]) -> Result<ParsedCert, CertParseError> {
         let mut pems = pem::parse_many(pem)?;
         if pems.len() < 2 {
             return Err(CertParseError::TooFewPem(pems.len()));
@@ -277,12 +281,16 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
 
         let validity = validity.expect("length checked above");
         let cert = CertifiedKey::new(cert_chain, pk);
-        Ok((cert, validity, required_schemes))
+        Ok(ParsedCert {
+            certified_key: cert,
+            validity,
+            signature_schemes: required_schemes,
+        })
     }
 
     #[allow(clippy::result_large_err)]
     fn process_cert(&mut self, pem: Vec<u8>, cached: bool) -> Event<EC, EA> {
-        let (cert, validity, schemes) = match (Self::parse_cert(&pem), cached) {
+        let parsed = match (Self::parse_cert(&pem), cached) {
             (Ok(r), _) => r,
             (Err(err), cached) => {
                 return match cached {
@@ -291,7 +299,9 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
                 }
             }
         };
-        self.resolver.set_cert(Arc::new(cert), schemes);
+        self.resolver
+            .set_cert(Arc::new(parsed.certified_key), parsed.signature_schemes);
+        let validity = parsed.validity;
         let wait_duration = (validity[1] - (validity[1] - validity[0]) / 3 - Utc::now())
             .max(chrono::Duration::zero())
             .to_std()
@@ -523,9 +533,11 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
                 self.load_alt_cert.take();
                 match result {
                     Ok(Some(pem)) => match Self::parse_cert(&pem) {
-                        Ok((alt_cert, _, schemes)) => {
-                            self.resolver
-                                .set_alt_cert(Some((Arc::new(alt_cert), schemes)));
+                        Ok(parsed) => {
+                            self.resolver.set_alt_cert(Some((
+                                Arc::new(parsed.certified_key),
+                                parsed.signature_schemes,
+                            )));
                         }
                         Err(err) => {
                             log::warn!("failed to parse cached alternate cert: {err}");
@@ -559,9 +571,11 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
                         // Set alternate cert if present (DualChain mode).
                         if let Some(alt_pem) = &order_result.alternate {
                             match Self::parse_cert(alt_pem) {
-                                Ok((alt_cert, _, schemes)) => {
-                                    self.resolver
-                                        .set_alt_cert(Some((Arc::new(alt_cert), schemes)));
+                                Ok(parsed) => {
+                                    self.resolver.set_alt_cert(Some((
+                                        Arc::new(parsed.certified_key),
+                                        parsed.signature_schemes,
+                                    )));
                                     // Store alt cert in cache.
                                     let alt_pem = alt_pem.clone();
                                     let config = self.config.clone();

--- a/src/state.rs
+++ b/src/state.rs
@@ -116,13 +116,16 @@ struct OrderResult {
     alternate: Option<Vec<u8>>,
 }
 
-/// Extract the subject common name of the last certificate (root) in a PEM chain.
+/// Extract the issuer common name of the last certificate in a PEM chain.
+/// For a typical chain [leaf, intermediate], this returns the CN of whoever
+/// signed the intermediate — i.e. the root CA, which may not be included
+/// in the chain itself.
 fn chain_root_issuer(cert_pem: &str) -> Option<String> {
     let pems = pem::parse_many(cert_pem).ok()?;
     let last_der = pems.last()?.contents().to_vec();
     let (_, cert) = parse_x509_certificate(&last_der).ok()?;
     let cn = cert
-        .subject()
+        .issuer()
         .iter_common_name()
         .next()
         .and_then(|cn| cn.as_str().ok())

--- a/src/state.rs
+++ b/src/state.rs
@@ -259,8 +259,7 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
         let mut validity = None;
         let mut required_schemes = Vec::new();
         for (i, der) in cert_chain.iter().enumerate() {
-            let (_, cert) = parse_x509_certificate(der.as_ref())
-                .map_err(CertParseError::X509)?;
+            let (_, cert) = parse_x509_certificate(der.as_ref()).map_err(CertParseError::X509)?;
             if i == 0 {
                 let v = cert.validity();
                 validity = Some(
@@ -373,7 +372,7 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
                 OrderStatus::Valid { certificate } => {
                     log::info!("download certificate");
                     let cert_response = account
-                        .certificate(&config.client_config, &certificate)
+                        .certificate_with_alternate_urls(&config.client_config, &certificate)
                         .await?;
                     let key_pem = key_pair.serialize_pem();
 
@@ -575,9 +574,7 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
                                             )
                                             .await
                                         {
-                                            log::warn!(
-                                                "failed to cache alternate cert: {err:?}"
-                                            );
+                                            log::warn!("failed to cache alternate cert: {err:?}");
                                         }
                                     });
                                 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -23,6 +23,7 @@ use crate::acceptor::AcmeAcceptor;
 use crate::acme::{
     Account, AcmeError, Auth, AuthStatus, Directory, Identifier, Order, OrderStatus,
 };
+use crate::cache::CertChainKind;
 use crate::config::CertChainPreference;
 use crate::{AcmeConfig, Incoming, ResolvesServerCertAcme};
 
@@ -110,22 +111,17 @@ struct OrderResult {
 }
 
 /// Extract the subject common name of the last certificate (root) in a PEM chain.
-/// The input should be a PEM string containing only certificates (no private key).
 fn chain_root_issuer(cert_pem: &str) -> Option<String> {
     let pems = pem::parse_many(cert_pem).ok()?;
-    let last_der: Vec<u8> = pems.last()?.contents().to_vec();
-    extract_subject_cn(&last_der)
-}
-
-fn extract_subject_cn(der: &[u8]) -> Option<String> {
-    let (_, cert) = parse_x509_certificate(der).ok()?;
-    let result = cert
+    let last_der = pems.last()?.contents().to_vec();
+    let (_, cert) = parse_x509_certificate(&last_der).ok()?;
+    let cn = cert
         .subject()
         .iter_common_name()
         .next()
         .and_then(|cn| cn.as_str().ok())
         .map(|s| s.to_string());
-    result
+    cn
 }
 
 impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
@@ -181,7 +177,11 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
                 async move {
                     config
                         .cache
-                        .load_cert(&config.domains, &config.directory_url)
+                        .load_cert(
+                            &config.domains,
+                            &config.directory_url,
+                            CertChainKind::Default,
+                        )
                         .await
                 }
             })),
@@ -190,7 +190,11 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
                 async move {
                     config
                         .cache
-                        .load_alt_cert(&config.domains, &config.directory_url)
+                        .load_cert(
+                            &config.domains,
+                            &config.directory_url,
+                            CertChainKind::Alternate,
+                        )
                         .await
                 }
             })),
@@ -258,7 +262,12 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
         self.early_action = Some(Box::pin(async move {
             match config
                 .cache
-                .store_cert(&config.domains, &config.directory_url, &pem)
+                .store_cert(
+                    &config.domains,
+                    &config.directory_url,
+                    CertChainKind::Default,
+                    &pem,
+                )
                 .await
             {
                 Ok(()) => Ok(EventOk::CertCacheStore),
@@ -327,83 +336,66 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
                         .await?;
                     let key_pem = key_pair.serialize_pem();
 
-                    let primary_pem =
-                        [&key_pem, "\n", &cert_response.pem].concat();
-
-                    let alternate = match &config.cert_chain {
-                        CertChainPreference::Default => None,
+                    let (primary, alternate) = match &config.cert_chain {
+                        CertChainPreference::Default => {
+                            let pem = [&key_pem, "\n", &cert_response.pem].concat().into_bytes();
+                            (pem, None)
+                        }
                         CertChainPreference::PreferredChain(issuer) => {
-                            Self::select_preferred_chain(
-                                &account,
-                                &config.client_config,
-                                &cert_response.pem,
-                                &cert_response.alternate_urls,
-                                issuer,
-                                &key_pem,
-                            )
-                            .await?
+                            let cert_pem =
+                                if chain_root_issuer(&cert_response.pem).as_deref() == Some(issuer)
+                                {
+                                    None
+                                } else {
+                                    Self::fetch_chain_by_issuer(
+                                        &account,
+                                        &config.client_config,
+                                        &cert_response.alternate_urls,
+                                        issuer,
+                                    )
+                                    .await?
+                                };
+                            let cert_pem = cert_pem.as_deref().unwrap_or(&cert_response.pem);
+                            let pem = [&key_pem, "\n", cert_pem].concat().into_bytes();
+                            (pem, None)
                         }
                         CertChainPreference::DualChain(issuer) => {
-                            Self::find_alternate_chain(
+                            let primary =
+                                [&key_pem, "\n", &cert_response.pem].concat().into_bytes();
+                            let alt = Self::fetch_chain_by_issuer(
                                 &account,
                                 &config.client_config,
-                                &cert_response.pem,
                                 &cert_response.alternate_urls,
                                 issuer,
-                                &key_pem,
                             )
-                            .await?
+                            .await?;
+                            let alternate = alt
+                                .map(|pem| [&key_pem, "\n", &pem].concat().into_bytes());
+                            (primary, alternate)
                         }
                     };
 
-                    // For PreferredChain, if we found a match, use it as primary.
-                    let primary = match &config.cert_chain {
-                        CertChainPreference::PreferredChain(_) if alternate.is_some() => {
-                            alternate.clone().unwrap()
-                        }
-                        _ => primary_pem.into_bytes(),
-                    };
-
-                    // For PreferredChain, alternate is used as primary so clear it.
-                    let alternate = match &config.cert_chain {
-                        CertChainPreference::PreferredChain(_) => None,
-                        _ => alternate,
-                    };
-
-                    return Ok(OrderResult {
-                        primary,
-                        alternate,
-                    });
+                    return Ok(OrderResult { primary, alternate });
                 }
                 OrderStatus::Invalid => return Err(OrderError::BadOrder(order)),
             }
         }
     }
-    /// Find an alternate chain matching the given issuer CN and return it as PEM bytes
-    /// (key + chain). Returns `None` if no match is found.
-    async fn find_alternate_chain(
+    /// Fetch the first alternate chain whose root issuer CN matches `target_issuer`.
+    /// Returns `None` if no match is found.
+    async fn fetch_chain_by_issuer(
         account: &Account,
         client_config: &Arc<rustls::ClientConfig>,
-        default_cert_pem: &str,
         alternate_urls: &[String],
         target_issuer: &str,
-        key_pem: &str,
-    ) -> Result<Option<Vec<u8>>, AcmeError> {
-        // Check if the default chain already matches.
-        if let Some(issuer) = chain_root_issuer(default_cert_pem) {
-            if issuer == target_issuer {
-                log::info!("default chain already matches preferred issuer '{target_issuer}'");
-                return Ok(Some([key_pem, "\n", default_cert_pem].concat().into_bytes()));
-            }
-        }
-        // Try each alternate chain URL.
+    ) -> Result<Option<String>, AcmeError> {
         for url in alternate_urls {
             log::info!("fetching alternate chain from {url}");
             let alt_pem = account.certificate_from_url(client_config, url).await?;
             if let Some(issuer) = chain_root_issuer(&alt_pem) {
                 log::info!("alternate chain root issuer: '{issuer}'");
                 if issuer == target_issuer {
-                    return Ok(Some([key_pem, "\n", &alt_pem].concat().into_bytes()));
+                    return Ok(Some(alt_pem));
                 }
             }
         }
@@ -411,32 +403,6 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
             "no alternate chain found matching issuer '{target_issuer}', using default chain"
         );
         Ok(None)
-    }
-    /// For PreferredChain: find matching alternate, or None to keep default.
-    async fn select_preferred_chain(
-        account: &Account,
-        client_config: &Arc<rustls::ClientConfig>,
-        default_cert_pem: &str,
-        alternate_urls: &[String],
-        target_issuer: &str,
-        key_pem: &str,
-    ) -> Result<Option<Vec<u8>>, AcmeError> {
-        // If default already matches, no need to search alternates.
-        if let Some(issuer) = chain_root_issuer(default_cert_pem) {
-            if issuer == target_issuer {
-                log::info!("default chain matches preferred issuer '{target_issuer}'");
-                return Ok(None);
-            }
-        }
-        Self::find_alternate_chain(
-            account,
-            client_config,
-            default_cert_pem,
-            alternate_urls,
-            target_issuer,
-            key_pem,
-        )
-        .await
     }
     async fn authorize(
         config: &AcmeConfig<EC, EA>,
@@ -509,16 +475,14 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
                 let result = ready!(load_alt_cert.poll_unpin(cx));
                 self.load_alt_cert.take();
                 match result {
-                    Ok(Some(pem)) => {
-                        match Self::parse_cert(&pem) {
-                            Ok((alt_cert, _)) => {
-                                self.resolver.set_alt_cert(Some(Arc::new(alt_cert)));
-                            }
-                            Err(err) => {
-                                log::warn!("failed to parse cached alternate cert: {err}");
-                            }
+                    Ok(Some(pem)) => match Self::parse_cert(&pem) {
+                        Ok((alt_cert, _)) => {
+                            self.resolver.set_alt_cert(Some(Arc::new(alt_cert)));
                         }
-                    }
+                        Err(err) => {
+                            log::warn!("failed to parse cached alternate cert: {err}");
+                        }
+                    },
                     Ok(None) => {}
                     Err(err) => {
                         log::warn!("failed to load cached alternate cert: {err:?}");
@@ -545,37 +509,36 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
                     Ok(order_result) => {
                         self.backoff_cnt = 0;
                         // Set alternate cert if present (DualChain mode).
-                        let alt_pem_for_cache = if let Some(alt_pem) = &order_result.alternate {
+                        if let Some(alt_pem) = &order_result.alternate {
                             match Self::parse_cert(alt_pem) {
                                 Ok((alt_cert, _)) => {
                                     self.resolver.set_alt_cert(Some(Arc::new(alt_cert)));
-                                    Some(alt_pem.clone())
+                                    // Store alt cert in cache.
+                                    let alt_pem = alt_pem.clone();
+                                    let config = self.config.clone();
+                                    tokio::spawn(async move {
+                                        if let Err(err) = config
+                                            .cache
+                                            .store_cert(
+                                                &config.domains,
+                                                &config.directory_url,
+                                                CertChainKind::Alternate,
+                                                &alt_pem,
+                                            )
+                                            .await
+                                        {
+                                            log::warn!(
+                                                "failed to cache alternate cert: {err:?}"
+                                            );
+                                        }
+                                    });
                                 }
                                 Err(err) => {
                                     log::warn!("failed to parse alternate cert chain: {err}");
-                                    None
                                 }
                             }
                         } else {
                             self.resolver.set_alt_cert(None);
-                            None
-                        };
-                        // Store alt cert in cache (fire-and-forget via early_action chain).
-                        if let Some(alt_pem) = alt_pem_for_cache {
-                            let config = self.config.clone();
-                            tokio::spawn(async move {
-                                if let Err(err) = config
-                                    .cache
-                                    .store_alt_cert(
-                                        &config.domains,
-                                        &config.directory_url,
-                                        &alt_pem,
-                                    )
-                                    .await
-                                {
-                                    log::warn!("failed to cache alternate cert: {err:?}");
-                                }
-                            });
                         }
                         return Poll::Ready(Self::process_cert(
                             self.get_mut(),

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -1,6 +1,6 @@
 //! Integration tests against a Pebble ACME test server.
 //!
-//! These tests require a running Pebble instance.
+//! These tests require a running Pebble instance with alternate roots enabled.
 //! Start it with: `docker compose -f docker-compose.pebble.yml up -d`
 //!
 //! Set `PEBBLE_MINICA_CERT` to the path of Pebble's minica root cert:
@@ -19,7 +19,7 @@ use rustls::{
 use tokio_rustls::TlsAcceptor;
 use tokio_rustls_acme::{
     caches::{DirCache, NoCache},
-    AccountCache, AcmeConfig, CertCache, EventOk, ResolvesServerCertAcme,
+    AccountCache, AcmeConfig, CertCache, CertChainPreference, EventOk, ResolvesServerCertAcme,
 };
 
 const PEBBLE_DIRECTORY: &str = "https://localhost:14000/dir";
@@ -61,6 +61,29 @@ fn http_client() -> reqwest::Client {
         .danger_accept_invalid_certs(true)
         .build()
         .unwrap()
+}
+
+/// Fetch the subject CN of a Pebble root by index (e.g., 0 = primary, 1 = first alternate).
+async fn fetch_root_cn(index: usize) -> String {
+    let url = format!("{PEBBLE_MGMT}/roots/{index}");
+    let pem_text = http_client()
+        .get(&url)
+        .send()
+        .await
+        .unwrap_or_else(|e| panic!("failed to fetch {}: {}", url, e))
+        .text()
+        .await
+        .unwrap();
+    let pems = pem::parse_many(&pem_text).expect("failed to parse root PEM");
+    let der = pems[0].contents().to_vec();
+    let (_, cert) = x509_parser::parse_x509_certificate(&der).expect("failed to parse root X509");
+    let cn = cert
+        .subject()
+        .iter_common_name()
+        .next()
+        .and_then(|cn| cn.as_str().ok())
+        .map(|s| s.to_string());
+    cn.expect("root cert has no CN")
 }
 
 /// Fetch Pebble's ACME-issued root + intermediate certs and build a root store
@@ -106,6 +129,7 @@ struct AcmeEvents {
 /// Run the ACME state machine until a certificate is deployed, collecting events.
 async fn acquire_cert_with_cache<C>(
     client_config: Arc<ClientConfig>,
+    cert_chain: CertChainPreference,
     cache: C,
 ) -> (Arc<ResolvesServerCertAcme>, AcmeEvents)
 where
@@ -114,6 +138,7 @@ where
     let config: AcmeConfig<io::Error> =
         AcmeConfig::new_with_client_tls_config([TEST_DOMAIN], client_config)
             .directory(PEBBLE_DIRECTORY)
+            .cert_chain(cert_chain)
             .cache(cache);
 
     let mut state = config.state();
@@ -155,8 +180,11 @@ where
 }
 
 /// Run the ACME state machine with NoCache until a certificate is deployed.
-async fn acquire_cert(client_config: Arc<ClientConfig>) -> Arc<ResolvesServerCertAcme> {
-    let (resolver, _) = acquire_cert_with_cache(client_config, NoCache::new()).await;
+async fn acquire_cert(
+    client_config: Arc<ClientConfig>,
+    cert_chain: CertChainPreference,
+) -> Arc<ResolvesServerCertAcme> {
+    let (resolver, _) = acquire_cert_with_cache(client_config, cert_chain, NoCache::new()).await;
     resolver
 }
 
@@ -214,7 +242,7 @@ async fn test_default_chain() {
     let _ = simple_logger::init_with_level(log::Level::Info);
 
     let client_config = pebble_client_config();
-    let resolver = acquire_cert(client_config).await;
+    let resolver = acquire_cert(client_config, CertChainPreference::Default).await;
 
     let root_store = pebble_acme_root_store().await;
     let peer_certs = verify_tls_handshake(resolver, root_store).await;
@@ -237,8 +265,12 @@ async fn test_dir_cache_stores_and_reloads() {
 
     // First run: fresh order, should store to cache.
     let client_config = pebble_client_config();
-    let (resolver, events) =
-        acquire_cert_with_cache(client_config.clone(), DirCache::new(cache_path.clone())).await;
+    let (resolver, events) = acquire_cert_with_cache(
+        client_config.clone(),
+        CertChainPreference::Default,
+        DirCache::new(cache_path.clone()),
+    )
+    .await;
     assert!(events.deployed_new, "first run should deploy a new cert");
     assert!(
         events.cert_cache_store,
@@ -251,8 +283,12 @@ async fn test_dir_cache_stores_and_reloads() {
     assert!(!peer_certs.is_empty());
 
     // Second run: same cache dir, should load from cache without ordering.
-    let (resolver2, events2) =
-        acquire_cert_with_cache(client_config, DirCache::new(cache_path)).await;
+    let (resolver2, events2) = acquire_cert_with_cache(
+        client_config,
+        CertChainPreference::Default,
+        DirCache::new(cache_path),
+    )
+    .await;
     assert!(
         events2.deployed_cached,
         "second run should deploy cached cert"
@@ -283,8 +319,12 @@ async fn test_account_cache_reuse() {
 
     // First run: registers a new account, stores it.
     let client_config = pebble_client_config();
-    let (_, events) =
-        acquire_cert_with_cache(client_config.clone(), DirCache::new(cache_path.clone())).await;
+    let (_, events) = acquire_cert_with_cache(
+        client_config.clone(),
+        CertChainPreference::Default,
+        DirCache::new(cache_path.clone()),
+    )
+    .await;
     assert!(
         events.account_cache_store,
         "first run should store account to cache"
@@ -303,7 +343,12 @@ async fn test_account_cache_reuse() {
     assert_eq!(entries.len(), 1, "should have exactly one cached account");
 
     // Second run: should load the cached account (no AccountCacheStore event).
-    let (_, events2) = acquire_cert_with_cache(client_config, DirCache::new(cache_path)).await;
+    let (_, events2) = acquire_cert_with_cache(
+        client_config,
+        CertChainPreference::Default,
+        DirCache::new(cache_path),
+    )
+    .await;
     assert!(
         !events2.account_cache_store,
         "second run should load cached account, not store a new one"
@@ -325,8 +370,12 @@ async fn test_corrupted_cache_triggers_reissue() {
 
     // First run: obtain and cache a valid cert.
     let client_config = pebble_client_config();
-    let (_, events) =
-        acquire_cert_with_cache(client_config.clone(), DirCache::new(cache_path.clone())).await;
+    let (_, events) = acquire_cert_with_cache(
+        client_config.clone(),
+        CertChainPreference::Default,
+        DirCache::new(cache_path.clone()),
+    )
+    .await;
     assert!(events.deployed_new);
 
     // Corrupt the cached cert file.
@@ -345,6 +394,7 @@ async fn test_corrupted_cache_triggers_reissue() {
     let config: AcmeConfig<io::Error> =
         AcmeConfig::new_with_client_tls_config([TEST_DOMAIN], client_config)
             .directory(PEBBLE_DIRECTORY)
+            .cert_chain(CertChainPreference::Default)
             .cache(DirCache::new(cache_path));
 
     let mut state = config.state();
@@ -407,6 +457,7 @@ async fn test_automatic_renewal() {
     let config: AcmeConfig<io::Error> =
         AcmeConfig::new_with_client_tls_config([TEST_DOMAIN], client_config)
             .directory(PEBBLE_DIRECTORY)
+            .cert_chain(CertChainPreference::Default)
             .cache(DirCache::new(cache_dir.path().to_path_buf()));
 
     let mut state = config.state();
@@ -508,4 +559,136 @@ async fn test_multi_domain_san() {
         );
     }
     eprintln!("multi-domain SANs: {sans:?}");
+}
+
+/// Select the alternate chain via PreferredChain and verify the issuer matches.
+///
+/// Pebble generates two independent CA hierarchies when PEBBLE_ALTERNATE_ROOTS=1.
+/// This test fetches the alternate root's CN from the management API, requests
+/// that chain via PreferredChain, and checks that the served intermediate was
+/// actually signed by the alternate root.
+#[tokio::test]
+#[ignore]
+async fn test_preferred_chain() {
+    let _ = simple_logger::init_with_level(log::Level::Info);
+
+    let alt_root_cn = fetch_root_cn(1).await;
+    eprintln!("alternate root CN: {alt_root_cn}");
+
+    let client_config = pebble_client_config();
+    let resolver = acquire_cert(
+        client_config,
+        CertChainPreference::PreferredChain(alt_root_cn.clone()),
+    )
+    .await;
+
+    let root_store = pebble_acme_root_store().await;
+    let peer_certs = verify_tls_handshake(resolver, root_store).await;
+    assert!(!peer_certs.is_empty(), "should have received certificates");
+
+    let last_cert_der = peer_certs.last().unwrap();
+    let (_, last_cert) = x509_parser::parse_x509_certificate(last_cert_der.as_ref()).unwrap();
+    let issuer_cn = last_cert
+        .issuer()
+        .iter_common_name()
+        .next()
+        .and_then(|cn| cn.as_str().ok())
+        .unwrap_or("");
+    eprintln!("preferred chain root issuer: {issuer_cn}");
+    assert_eq!(
+        issuer_cn, alt_root_cn,
+        "chain should be issued by the preferred alternate root"
+    );
+}
+
+/// Fetch both chains with DualChain and verify TLS works with the primary.
+///
+/// DualChain stores both the default and an alternate chain, serving the
+/// alternate to clients that cannot verify the primary's signature schemes.
+/// This test verifies the basic DualChain flow completes and the primary
+/// chain is usable in a TLS handshake.
+#[tokio::test]
+#[ignore]
+async fn test_dual_chain() {
+    let _ = simple_logger::init_with_level(log::Level::Info);
+
+    let alt_root_cn = fetch_root_cn(1).await;
+    eprintln!("alternate root CN: {alt_root_cn}");
+
+    let client_config = pebble_client_config();
+    let resolver = acquire_cert(client_config, CertChainPreference::DualChain(alt_root_cn)).await;
+
+    let root_store = pebble_acme_root_store().await;
+    let peer_certs = verify_tls_handshake(resolver, root_store).await;
+    assert!(!peer_certs.is_empty(), "should have received certificates");
+    eprintln!(
+        "dual chain: received {} certificates from primary",
+        peer_certs.len()
+    );
+}
+
+/// Verify that DualChain mode caches the alternate chain separately.
+///
+/// When using DualChain with DirCache, both the default and alternate cert
+/// PEM bundles should be written to disk as separate files. A second run
+/// should load both from cache without contacting the ACME server.
+#[tokio::test]
+#[ignore]
+async fn test_dual_chain_cache() {
+    let _ = simple_logger::init_with_level(log::Level::Info);
+
+    let cache_dir = tempfile::tempdir().unwrap();
+    let cache_path: PathBuf = cache_dir.path().into();
+    let alt_root_cn = fetch_root_cn(1).await;
+
+    // First run: orders cert with DualChain, caches both chains.
+    let client_config = pebble_client_config();
+    let (_, events) = acquire_cert_with_cache(
+        client_config.clone(),
+        CertChainPreference::DualChain(alt_root_cn.clone()),
+        DirCache::new(cache_path.clone()),
+    )
+    .await;
+    assert!(events.deployed_new);
+    assert!(events.cert_cache_store);
+
+    // Should have both a default and an alternate cert file.
+    let cert_files: Vec<_> = std::fs::read_dir(&cache_path)
+        .unwrap()
+        .filter_map(|e| e.ok())
+        .filter(|e| {
+            e.file_name()
+                .to_str()
+                .is_some_and(|n| n.starts_with("cached_cert_"))
+        })
+        .collect();
+    assert!(
+        cert_files.len() >= 2,
+        "should have at least 2 cached cert files (default + alt), got {}",
+        cert_files.len()
+    );
+    let has_alt = cert_files
+        .iter()
+        .any(|e| e.file_name().to_str().is_some_and(|n| n.ends_with("_alt")));
+    assert!(has_alt, "should have an alternate cert cache file");
+
+    // Give the background alt cert cache task time to complete.
+    tokio::time::sleep(Duration::from_millis(500)).await;
+
+    // Second run: should load both chains from cache.
+    let (resolver, events2) = acquire_cert_with_cache(
+        client_config,
+        CertChainPreference::DualChain(alt_root_cn),
+        DirCache::new(cache_path),
+    )
+    .await;
+    assert!(
+        events2.deployed_cached,
+        "second run should deploy cached cert"
+    );
+
+    // Verify the cached cert still works in a TLS handshake.
+    let root_store = pebble_acme_root_store().await;
+    let peer_certs = verify_tls_handshake(resolver, root_store).await;
+    assert!(!peer_certs.is_empty());
 }


### PR DESCRIPTION
Based on #40 

* Add support for using alternate chains
* Add support for dual chain mode (using both the primary and the alternate chain)
* In dual chain mode, select the alternate chain if the client does not support the signature schemes required by the primary chain

This is intended for supporting Let's Encrypt alternate chain "X2" which uses an Ed25519 root cert instead of an RSA root cert. With this change, when configuring with dual chain or alternate chain mode, we can support clients that don't support RSA but only Ed25519.