### PR TITLE
feat!: add IP address certificate support

### DIFF
--- a/src/acme.rs
+++ b/src/acme.rs
@@ -126,7 +126,10 @@ impl Account {
         client_config: &Arc<ClientConfig>,
         domains: Vec<String>,
     ) -> Result<(String, Order), AcmeError> {
-        let domains: Vec<Identifier> = domains.into_iter().map(Identifier::from_str).collect();
+        let domains: Vec<Identifier> = domains
+            .into_iter()
+            .map(Identifier::parse_from_str)
+            .collect();
         let payload = format!("{{\"identifiers\":{}}}", serde_json::to_string(&domains)?);
         let response = self
             .request(client_config, &self.directory.new_order, &payload)
@@ -309,7 +312,7 @@ pub enum Identifier {
 
 impl Identifier {
     /// Auto-detect whether the string is an IP address or DNS name.
-    pub fn from_str(s: impl Into<String>) -> Self {
+    pub fn parse_from_str(s: impl Into<String>) -> Self {
         let s = s.into();
         if s.parse::<std::net::IpAddr>().is_ok() {
             Identifier::Ip(s)

--- a/src/acme.rs
+++ b/src/acme.rs
@@ -126,7 +126,7 @@ impl Account {
         client_config: &Arc<ClientConfig>,
         domains: Vec<String>,
     ) -> Result<(String, Order), AcmeError> {
-        let domains: Vec<Identifier> = domains.into_iter().map(Identifier::Dns).collect();
+        let domains: Vec<Identifier> = domains.into_iter().map(Identifier::from_str).collect();
         let payload = format!("{{\"identifiers\":{}}}", serde_json::to_string(&domains)?);
         let response = self
             .request(client_config, &self.directory.new_order, &payload)
@@ -296,10 +296,33 @@ pub enum AuthStatus {
     Deactivated,
 }
 
+/// ACME identifier per RFC 8555 §9.7.7.
+///
+/// Serializes as `{"type":"dns","value":"..."}` or `{"type":"ip","value":"..."}`.
+/// IP identifier support is defined in RFC 8738.
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(tag = "type", content = "value", rename_all = "camelCase")]
 pub enum Identifier {
     Dns(String),
+    Ip(String),
+}
+
+impl Identifier {
+    /// Auto-detect whether the string is an IP address or DNS name.
+    pub fn from_str(s: impl Into<String>) -> Self {
+        let s = s.into();
+        if s.parse::<std::net::IpAddr>().is_ok() {
+            Identifier::Ip(s)
+        } else {
+            Identifier::Dns(s)
+        }
+    }
+    /// Extract the inner value regardless of variant.
+    pub fn as_str(&self) -> &str {
+        match self {
+            Identifier::Dns(v) | Identifier::Ip(v) => v,
+        }
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/state.rs
+++ b/src/state.rs
@@ -20,9 +20,7 @@ use tokio::time::Sleep;
 use x509_parser::parse_x509_certificate;
 
 use crate::acceptor::AcmeAcceptor;
-use crate::acme::{
-    Account, AcmeError, Auth, AuthStatus, Directory, Identifier, Order, OrderStatus,
-};
+use crate::acme::{Account, AcmeError, Auth, AuthStatus, Directory, Order, OrderStatus};
 use crate::{AcmeConfig, Incoming, ResolvesServerCertAcme};
 
 type Timer = std::pin::Pin<Box<Sleep>>;
@@ -310,7 +308,7 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
         let auth = account.auth(&config.client_config, url).await?;
         let (domain, challenge_url) = match auth.status {
             AuthStatus::Pending => {
-                let Identifier::Dns(domain) = auth.identifier;
+                let domain = auth.identifier.as_str().to_string();
                 log::info!("trigger challenge for {}", &domain);
                 let (challenge, auth_key) =
                     account.tls_alpn_01(&auth.challenges, domain.clone())?;

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -9,7 +9,7 @@
 //!
 //! Run with: `cargo test --test pebble -- --ignored`
 
-use std::{convert::TryFrom, io, path::PathBuf, sync::Arc, time::Duration};
+use std::{convert::TryFrom, io, net::IpAddr, path::PathBuf, sync::Arc, time::Duration};
 
 use futures::StreamExt;
 use rustls::{
@@ -508,4 +508,148 @@ async fn test_multi_domain_san() {
         );
     }
     eprintln!("multi-domain SANs: {sans:?}");
+}
+
+const TEST_IP: &str = "10.30.50.1";
+
+/// Helper: run ACME state machine for given identifiers until cert is deployed.
+async fn acquire_cert_for(
+    client_config: Arc<ClientConfig>,
+    identifiers: &[&str],
+) -> Arc<ResolvesServerCertAcme> {
+    let config: AcmeConfig<io::Error> =
+        AcmeConfig::new_with_client_tls_config(identifiers, client_config)
+            .directory(PEBBLE_DIRECTORY)
+            .cache(NoCache::new());
+
+    let mut state = config.state();
+    let resolver = state.resolver();
+
+    tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            match state.next().await {
+                Some(Ok(EventOk::DeployedNewCert)) => return,
+                Some(Ok(_)) => {}
+                Some(Err(err)) => panic!("ACME error: {:?}", err),
+                None => panic!("state stream ended unexpectedly"),
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for certificate deployment");
+
+    resolver
+}
+
+/// Do an in-process TLS handshake using an IP address as the server name.
+async fn verify_tls_handshake_ip(
+    resolver: Arc<ResolvesServerCertAcme>,
+    root_store: RootCertStore,
+    ip: IpAddr,
+) -> Vec<CertificateDer<'static>> {
+    let server_config = Arc::new(
+        ServerConfig::builder()
+            .with_no_client_auth()
+            .with_cert_resolver(resolver),
+    );
+    let acceptor = TlsAcceptor::from(server_config);
+
+    let client_config = Arc::new(
+        ClientConfig::builder()
+            .with_root_certificates(root_store)
+            .with_no_client_auth(),
+    );
+    let connector = tokio_rustls::TlsConnector::from(client_config);
+
+    let (client_io, server_io) = tokio::io::duplex(4096);
+    let server_name = ServerName::from(ip);
+
+    let (client_result, server_result) = tokio::join!(
+        connector.connect(server_name, client_io),
+        acceptor.accept(server_io),
+    );
+
+    let _ = server_result.expect("TLS server handshake failed");
+    let client_tls = client_result.expect("TLS client handshake failed");
+    let (_, conn) = client_tls.get_ref();
+    conn.peer_certificates()
+        .expect("no peer certificates")
+        .to_vec()
+}
+
+/// Issue a certificate for an IP address and verify TLS works with an IP SAN.
+#[tokio::test]
+#[ignore]
+async fn test_ip_certificate() {
+    let _ = simple_logger::init_with_level(log::Level::Info);
+
+    let client_config = pebble_client_config();
+    let resolver = acquire_cert_for(client_config, &[TEST_IP]).await;
+
+    let root_store = pebble_acme_root_store().await;
+    let ip: IpAddr = TEST_IP.parse().unwrap();
+    let peer_certs = verify_tls_handshake_ip(resolver, root_store, ip).await;
+    assert!(!peer_certs.is_empty(), "should have received certificates");
+
+    // Verify the leaf certificate contains an IP SAN.
+    let (_, leaf) = x509_parser::parse_x509_certificate(peer_certs[0].as_ref()).unwrap();
+    let san = leaf
+        .subject_alternative_name()
+        .expect("SAN extension missing")
+        .expect("SAN extension empty");
+    let has_ip = san
+        .value
+        .general_names
+        .iter()
+        .any(|name| matches!(name, x509_parser::extensions::GeneralName::IPAddress(_)));
+    assert!(has_ip, "certificate should contain an IP SAN");
+    eprintln!("IP certificate issued successfully for {TEST_IP}");
+}
+
+/// Issue a certificate with both IP and DNS identifiers in a single order.
+#[tokio::test]
+#[ignore]
+async fn test_mixed_ip_and_domain() {
+    let _ = simple_logger::init_with_level(log::Level::Info);
+
+    let mixed_ip = "10.30.50.2";
+    let mixed_domain = "mixed.example.com";
+
+    let client_config = pebble_client_config();
+    let resolver = acquire_cert_for(client_config, &[mixed_ip, mixed_domain]).await;
+
+    let root_store = pebble_acme_root_store().await;
+
+    // Verify TLS handshake using the IP address.
+    let ip: IpAddr = mixed_ip.parse().unwrap();
+    let peer_certs = verify_tls_handshake_ip(resolver.clone(), root_store, ip).await;
+    assert!(!peer_certs.is_empty());
+
+    // Verify TLS handshake using the domain name.
+    let root_store = pebble_acme_root_store().await;
+    let peer_certs = verify_tls_handshake_for(resolver, root_store, mixed_domain).await;
+    assert!(!peer_certs.is_empty());
+
+    // Parse leaf and check both SAN types are present.
+    let (_, leaf) = x509_parser::parse_x509_certificate(peer_certs[0].as_ref()).unwrap();
+    let san = leaf
+        .subject_alternative_name()
+        .expect("SAN extension missing")
+        .expect("SAN extension empty");
+
+    let has_ip = san
+        .value
+        .general_names
+        .iter()
+        .any(|name| matches!(name, x509_parser::extensions::GeneralName::IPAddress(_)));
+    let has_dns = san.value.general_names.iter().any(|name| {
+        matches!(name, x509_parser::extensions::GeneralName::DNSName(d) if *d == mixed_domain)
+    });
+    assert!(has_ip, "certificate should contain an IP SAN");
+    assert!(
+        has_dns,
+        "certificate should contain a DNS SAN for {}",
+        mixed_domain
+    );
+    eprintln!("mixed IP+domain certificate issued successfully");
 }


### PR DESCRIPTION
This adds support for IP certificates, as specified in  RFC 8738. 

The change is straightforward, we just need to request the correct type in the certificate order. Everything else doesn't need any changes.

## Breaking changes

This is a breaking change because the public enum `acme::Identifier` gained a new variant.
This is unfortunate, because this does not actually have to be public. We should do a cleanup pass to make more things non-public to reduce public API surface.