### PR TITLE
feat!: allow to set the crypto provider

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -84,9 +84,6 @@ jobs:
       - name: cargo check
         run: cargo check --no-default-features --features ${{ matrix.features }} --lib --tests
       - name: cargo test
-        # The no-built-in-provider build can't run the in-process handshake
-        # tests (they install ring or aws-lc-rs explicitly), so skip them.
-        if: matrix.name != 'no built-in provider'
         run: cargo test --no-default-features --features ${{ matrix.features }} --tests
 
   # Checks correct runtime deps and features are requested by not including dev-dependencies.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,13 +68,13 @@ jobs:
       matrix:
         include:
           - name: "ring only"
-            features: "rustls-tls-webpki-roots,ring"
+            features: "tls-webpki-roots,tls-ring"
           - name: "aws-lc-rs only"
-            features: "rustls-tls-webpki-roots,aws-lc-rs"
+            features: "tls-webpki-roots,tls-aws-lc-rs"
           - name: "ring and aws-lc-rs"
-            features: "rustls-tls-webpki-roots,ring,aws-lc-rs"
+            features: "tls-webpki-roots,tls-ring,tls-aws-lc-rs"
           - name: "no built-in provider"
-            features: "rustls-tls-webpki-roots"
+            features: "tls-webpki-roots"
     env:
       RUSTC_WRAPPER: "sccache"
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,37 @@ jobs:
       - name: cargo test
         run: cargo test --workspace --all-features --bins --tests --examples
 
+  # Verifies the crate compiles and tests pass under each crypto provider
+  # feature combo, including the "no built-in provider" mode where the caller
+  # must inject one via AcmeConfig::crypto_provider.
+  feature-combos:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: "ring only"
+            features: "rustls-tls-webpki-roots,ring"
+          - name: "aws-lc-rs only"
+            features: "rustls-tls-webpki-roots,aws-lc-rs"
+          - name: "ring and aws-lc-rs"
+            features: "rustls-tls-webpki-roots,ring,aws-lc-rs"
+          - name: "no built-in provider"
+            features: "rustls-tls-webpki-roots"
+    env:
+      RUSTC_WRAPPER: "sccache"
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+      - uses: mozilla-actions/sccache-action@v0.0.9
+      - name: cargo check
+        run: cargo check --no-default-features --features ${{ matrix.features }} --lib --tests
+      - name: cargo test
+        # The no-built-in-provider build can't run the in-process handshake
+        # tests (they install ring or aws-lc-rs explicitly), so skip them.
+        if: matrix.name != 'no built-in provider'
+        run: cargo test --no-default-features --features ${{ matrix.features }} --tests
+
   # Checks correct runtime deps and features are requested by not including dev-dependencies.
   check-deps:
     runs-on: ubuntu-latest

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,6 +64,11 @@ warp = "0.3"
 tempfile = "3"
 pem = "3.0"
 x509-parser = "0.18"
+# Pulled in only for the integration tests so they can construct a
+# `CryptoProvider` regardless of which crate features are enabled. Cargo
+# applies dev-dep features to test/example/bench builds only, so this does
+# not enable rustls's `ring` feature in downstream library builds.
+rustls = { version = "0.23", default-features = false, features = ["ring"] }
 
 [package.metadata.docs.rs]
 all-features = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -75,16 +75,16 @@ all-features = true
 rustdoc-args = ["--cfg", "doc_auto_cfg"]
 
 [features]
-default = ["rustls-tls-webpki-roots", "ring"]
+default = ["tls-webpki-roots", "tls-ring"]
 axum = ["dep:axum-server"]
-rustls-tls-webpki-roots = ["dep:webpki-roots"]
+tls-webpki-roots = ["dep:webpki-roots"]
 # Enables the ring rustls crypto provider. When enabled, rustls auto-installs
 # ring as the default provider; otherwise the user must call
 # `AcmeConfig::crypto_provider` or `CryptoProvider::install_default`.
-ring = ["rustls/ring", "tokio-rustls/ring"]
+tls-ring = ["rustls/ring", "tokio-rustls/ring"]
 # Enables the aws-lc-rs rustls crypto provider. When this is the only crypto
 # feature enabled, rustls auto-installs aws-lc-rs as the default provider.
-aws-lc-rs = ["rustls/aws-lc-rs", "tokio-rustls/aws-lc-rs"]
+tls-aws-lc-rs = ["rustls/aws-lc-rs", "tokio-rustls/aws-lc-rs"]
 
 [[example]]
 name = "low_level_axum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,12 +78,11 @@ rustdoc-args = ["--cfg", "doc_auto_cfg"]
 default = ["tls-webpki-roots", "tls-ring"]
 axum = ["dep:axum-server"]
 tls-webpki-roots = ["dep:webpki-roots"]
-# Enables the ring rustls crypto provider. When enabled, rustls auto-installs
-# ring as the default provider; otherwise the user must call
-# `AcmeConfig::crypto_provider` or `CryptoProvider::install_default`.
+# Picks the ring rustls crypto provider for `AcmeConfig::new`. With both
+# `tls-ring` and `tls-aws-lc-rs` (or neither), the caller must use
+# `AcmeConfig::new_with_crypto_provider` to disambiguate.
 tls-ring = ["rustls/ring", "tokio-rustls/ring"]
-# Enables the aws-lc-rs rustls crypto provider. When this is the only crypto
-# feature enabled, rustls auto-installs aws-lc-rs as the default provider.
+# Picks the aws-lc-rs rustls crypto provider for `AcmeConfig::new`.
 tls-aws-lc-rs = ["rustls/aws-lc-rs", "tokio-rustls/aws-lc-rs"]
 
 [[example]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ thiserror = "2.0"
 x509-parser = "0.18"
 chrono = { version = "0.4.24", default-features = false, features = ["clock"] }
 async-trait = "0.1.53"
-rustls = { version = "0.23", default-features = false, features = ["ring"] }
+rustls = { version = "0.23", default-features = false }
 time = "0.3.36"                                                                 # force the transitive dependency to a more recent minimal version. The build fails with 0.3.20
 
 tokio = { version = "1.20.1", default-features = false }
@@ -62,6 +62,7 @@ tokio-stream = { version = "0.1.9", features = ["net"] }
 tokio-util = { version = "0.7.3", features = ["compat"] }
 warp = "0.3"
 tempfile = "3"
+pem = "3.0"
 x509-parser = "0.18"
 
 [package.metadata.docs.rs]
@@ -69,9 +70,16 @@ all-features = true
 rustdoc-args = ["--cfg", "doc_auto_cfg"]
 
 [features]
-default = ["rustls-tls-webpki-roots"]
+default = ["rustls-tls-webpki-roots", "ring"]
 axum = ["dep:axum-server"]
 rustls-tls-webpki-roots = ["dep:webpki-roots"]
+# Enables the ring rustls crypto provider. When enabled, rustls auto-installs
+# ring as the default provider; otherwise the user must call
+# `AcmeConfig::crypto_provider` or `CryptoProvider::install_default`.
+ring = ["rustls/ring", "tokio-rustls/ring"]
+# Enables the aws-lc-rs rustls crypto provider. When this is the only crypto
+# feature enabled, rustls auto-installs aws-lc-rs as the default provider.
+aws-lc-rs = ["rustls/aws-lc-rs", "tokio-rustls/aws-lc-rs"]
 
 [[example]]
 name = "low_level_axum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,11 +78,11 @@ rustdoc-args = ["--cfg", "doc_auto_cfg"]
 default = ["tls-webpki-roots", "tls-ring"]
 axum = ["dep:axum-server"]
 tls-webpki-roots = ["dep:webpki-roots"]
-# Picks the ring rustls crypto provider for `AcmeConfig::new`. With both
-# `tls-ring` and `tls-aws-lc-rs` (or neither), the caller must use
-# `AcmeConfig::new_with_crypto_provider` to disambiguate.
+# Picks the ring rustls crypto provider for `AcmeConfig::new`. Takes
+# precedence over `tls-aws-lc-rs` when both are enabled.
 tls-ring = ["rustls/ring", "tokio-rustls/ring"]
-# Picks the aws-lc-rs rustls crypto provider for `AcmeConfig::new`.
+# Picks the aws-lc-rs rustls crypto provider for `AcmeConfig::new` when
+# `tls-ring` is not also enabled.
 tls-aws-lc-rs = ["rustls/aws-lc-rs", "tokio-rustls/aws-lc-rs"]
 
 [[example]]

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -47,7 +47,7 @@ args = [
     "test",
     "--no-default-features",
     "--features",
-    "rustls-tls-webpki-roots,ring",
+    "tls-webpki-roots,tls-ring",
     "--tests",
 ]
 
@@ -58,7 +58,7 @@ args = [
     "test",
     "--no-default-features",
     "--features",
-    "rustls-tls-webpki-roots,aws-lc-rs",
+    "tls-webpki-roots,tls-aws-lc-rs",
     "--tests",
 ]
 
@@ -69,7 +69,7 @@ args = [
     "test",
     "--no-default-features",
     "--features",
-    "rustls-tls-webpki-roots,ring,aws-lc-rs",
+    "tls-webpki-roots,tls-ring,tls-aws-lc-rs",
     "--tests",
 ]
 
@@ -80,7 +80,7 @@ args = [
     "test",
     "--no-default-features",
     "--features",
-    "rustls-tls-webpki-roots",
+    "tls-webpki-roots",
     "--tests",
 ]
 

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -39,3 +39,56 @@ args = ["test", "--test", "pebble", "--", "--ignored", "--nocapture"]
 clear = true
 description = "Run Pebble integration tests e2e (start server, test, stop)"
 run_task = { name = ["pebble-test-run"], fork = true, cleanup_task = "pebble-down" }
+
+[tasks.test-ring]
+description = "Run tests with only the ring crypto provider feature enabled"
+command = "cargo"
+args = [
+    "test",
+    "--no-default-features",
+    "--features",
+    "rustls-tls-webpki-roots,ring",
+    "--tests",
+]
+
+[tasks.test-aws-lc-rs]
+description = "Run tests with only the aws-lc-rs crypto provider feature enabled"
+command = "cargo"
+args = [
+    "test",
+    "--no-default-features",
+    "--features",
+    "rustls-tls-webpki-roots,aws-lc-rs",
+    "--tests",
+]
+
+[tasks.test-both-providers]
+description = "Run tests with both ring and aws-lc-rs crypto provider features enabled"
+command = "cargo"
+args = [
+    "test",
+    "--no-default-features",
+    "--features",
+    "rustls-tls-webpki-roots,ring,aws-lc-rs",
+    "--tests",
+]
+
+[tasks.test-no-provider]
+description = "Run tests with neither crypto provider feature enabled"
+command = "cargo"
+args = [
+    "test",
+    "--no-default-features",
+    "--features",
+    "rustls-tls-webpki-roots",
+    "--tests",
+]
+
+[tasks.test-feature-combos]
+description = "Run the full crypto provider feature matrix the CI uses"
+dependencies = [
+    "test-ring",
+    "test-aws-lc-rs",
+    "test-both-providers",
+    "test-no-provider",
+]

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">tokio-rustls-acme</h1>
 <div align="center">
  <strong>
-    Automatic TLS certificate management using rustls with ring.
+    Automatic TLS certificate management using rustls.
  </strong>
 </div>
 
@@ -36,7 +36,7 @@
 
 > Original implementation based on https://github.com/FlorianUekermann/rustls-acme. 
 
-An easy-to-use, async compatible [ACME] client library using [rustls] with [ring].
+An easy-to-use, async compatible [ACME] client library using [rustls].
 The validation mechanism used is tls-alpn-01, which allows serving acme challenge responses and
 regular TLS traffic on the same port.
 
@@ -49,9 +49,11 @@ is folded into the streams and futures being polled by the library user.
 The goal is to provide a [Let's Encrypt](https://letsencrypt.org/) compatible TLS serving and
 certificate management using a simple and flexible stream based API.
 
-This crate uses [ring] as [rustls]'s backend, instead of [aws-lc-rs]. This generally makes it
-much easier to compile. If you'd like to use [aws-lc-rs] as [rustls]'s backend, we're open to
-contributions with the necessary `Cargo.toml` changes and feature-flags to enable you to do so.
+The default `tls-ring` feature selects [ring] as rustls's crypto backend.
+To use [aws-lc-rs] instead, disable default features and enable
+`tls-aws-lc-rs`. The selected provider flows through to the HTTPS client,
+the TLS handshake, and key parsing; the crate never reads or installs
+the process-wide default provider.
 
 To use tokio-rustls-acme add the following lines to your `Cargo.toml`:
 

--- a/examples/low_level.rs
+++ b/examples/low_level.rs
@@ -1,5 +1,5 @@
 use clap::Parser;
-use rustls::ServerConfig;
+use rustls::{ServerConfig, DEFAULT_VERSIONS};
 use std::net::Ipv6Addr;
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -41,7 +41,9 @@ async fn main() {
         .cache_option(args.cache.clone().map(DirCache::new))
         .directory_lets_encrypt(args.prod)
         .state();
-    let rustls_config = ServerConfig::builder()
+    let rustls_config = ServerConfig::builder_with_provider(state.crypto_provider())
+        .with_protocol_versions(DEFAULT_VERSIONS)
+        .unwrap()
         .with_no_client_auth()
         .with_cert_resolver(state.resolver());
     let acceptor = state.acceptor();

--- a/examples/low_level_axum.rs
+++ b/examples/low_level_axum.rs
@@ -1,6 +1,6 @@
 use axum::{routing::get, Router};
 use clap::Parser;
-use rustls::ServerConfig;
+use rustls::{ServerConfig, DEFAULT_VERSIONS};
 use std::net::{Ipv6Addr, SocketAddr};
 use std::path::PathBuf;
 use std::sync::Arc;
@@ -41,7 +41,9 @@ async fn main() {
         .cache_option(args.cache.clone().map(DirCache::new))
         .directory_lets_encrypt(args.prod)
         .state();
-    let rustls_config = ServerConfig::builder()
+    let rustls_config = ServerConfig::builder_with_provider(state.crypto_provider())
+        .with_protocol_versions(DEFAULT_VERSIONS)
+        .unwrap()
         .with_no_client_auth()
         .with_cert_resolver(state.resolver());
     let acceptor = state.axum_acceptor(Arc::new(rustls_config));

--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -1,7 +1,8 @@
 use crate::acme::ACME_TLS_ALPN_NAME;
 use crate::ResolvesServerCertAcme;
+use rustls::crypto::CryptoProvider;
 use rustls::server::Acceptor;
-use rustls::ServerConfig;
+use rustls::{ConfigBuilder, ServerConfig, WantsVerifier, DEFAULT_VERSIONS};
 use std::future::Future;
 use std::io;
 use std::pin::Pin;
@@ -17,9 +18,25 @@ pub struct AcmeAcceptor {
 
 impl AcmeAcceptor {
     pub(crate) fn new(resolver: Arc<ResolvesServerCertAcme>) -> Self {
-        let mut config = ServerConfig::builder()
-            .with_no_client_auth()
-            .with_cert_resolver(resolver);
+        Self::new_with_config_builder(resolver, ServerConfig::builder())
+    }
+
+    pub(crate) fn new_with_crypto_provider(
+        resolver: Arc<ResolvesServerCertAcme>,
+        crypto_provider: Arc<CryptoProvider>,
+    ) -> Self {
+        let builder = ServerConfig::builder_with_provider(crypto_provider)
+            // Replicates what [`ServerConfig::builder`] does.
+            .with_protocol_versions(DEFAULT_VERSIONS)
+            .unwrap();
+        Self::new_with_config_builder(resolver, builder)
+    }
+
+    pub(crate) fn new_with_config_builder(
+        resolver: Arc<ResolvesServerCertAcme>,
+        builder: ConfigBuilder<ServerConfig, WantsVerifier>,
+    ) -> Self {
+        let mut config = builder.with_no_client_auth().with_cert_resolver(resolver);
         config.alpn_protocols.push(ACME_TLS_ALPN_NAME.to_vec());
         Self {
             config: Arc::new(config),

--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -11,6 +11,8 @@ use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_rustls::{Accept, LazyConfigAcceptor, StartHandshake};
 
+/// Accepts incoming TLS connections, handling `tls-alpn-01` validation
+/// inline and forwarding application traffic to the caller.
 #[derive(Clone)]
 pub struct AcmeAcceptor {
     config: Arc<ServerConfig>,
@@ -31,11 +33,18 @@ impl AcmeAcceptor {
             config: Arc::new(config),
         }
     }
+
+    /// Starts handshake processing on `io`.
+    ///
+    /// The returned future resolves to `Some(handshake)` for application
+    /// traffic the caller should finish, or `None` when the connection was
+    /// a `tls-alpn-01` validation already handled internally.
     pub fn accept<IO: AsyncRead + AsyncWrite + Unpin>(&self, io: IO) -> AcmeAccept<IO> {
         AcmeAccept::new(io, self.config.clone())
     }
 }
 
+/// Future returned by [`AcmeAcceptor::accept`].
 pub struct AcmeAccept<IO: AsyncRead + AsyncWrite + Unpin> {
     acceptor: LazyConfigAcceptor<IO>,
     config: Arc<ServerConfig>,

--- a/src/acceptor.rs
+++ b/src/acceptor.rs
@@ -2,7 +2,7 @@ use crate::acme::ACME_TLS_ALPN_NAME;
 use crate::ResolvesServerCertAcme;
 use rustls::crypto::CryptoProvider;
 use rustls::server::Acceptor;
-use rustls::{ConfigBuilder, ServerConfig, WantsVerifier, DEFAULT_VERSIONS};
+use rustls::{ServerConfig, DEFAULT_VERSIONS};
 use std::future::Future;
 use std::io;
 use std::pin::Pin;
@@ -17,26 +17,15 @@ pub struct AcmeAcceptor {
 }
 
 impl AcmeAcceptor {
-    pub(crate) fn new(resolver: Arc<ResolvesServerCertAcme>) -> Self {
-        Self::new_with_config_builder(resolver, ServerConfig::builder())
-    }
-
-    pub(crate) fn new_with_crypto_provider(
+    pub(crate) fn new(
         resolver: Arc<ResolvesServerCertAcme>,
         crypto_provider: Arc<CryptoProvider>,
     ) -> Self {
-        let builder = ServerConfig::builder_with_provider(crypto_provider)
-            // Replicates what [`ServerConfig::builder`] does.
+        let mut config = ServerConfig::builder_with_provider(crypto_provider)
             .with_protocol_versions(DEFAULT_VERSIONS)
-            .unwrap();
-        Self::new_with_config_builder(resolver, builder)
-    }
-
-    pub(crate) fn new_with_config_builder(
-        resolver: Arc<ResolvesServerCertAcme>,
-        builder: ConfigBuilder<ServerConfig, WantsVerifier>,
-    ) -> Self {
-        let mut config = builder.with_no_client_auth().with_cert_resolver(resolver);
+            .expect("rustls DEFAULT_VERSIONS is always valid")
+            .with_no_client_auth()
+            .with_cert_resolver(resolver);
         config.alpn_protocols.push(ACME_TLS_ALPN_NAME.to_vec());
         Self {
             config: Arc::new(config),

--- a/src/acme.rs
+++ b/src/acme.rs
@@ -8,8 +8,9 @@ use rcgen::{CustomExtension, Error as RcgenError, PKCS_ECDSA_P256_SHA256};
 use ring::error::{KeyRejected, Unspecified};
 use ring::rand::SystemRandom;
 use ring::signature::{EcdsaKeyPair, EcdsaSigningAlgorithm, ECDSA_P256_SHA256_FIXED_SIGNING};
-use rustls::{crypto::ring::sign::any_ecdsa_type, sign::CertifiedKey};
+use rustls::sign::CertifiedKey;
 use rustls::{
+    crypto::CryptoProvider,
     pki_types::{PrivateKeyDer, PrivatePkcs8KeyDer},
     ClientConfig,
 };
@@ -179,6 +180,7 @@ impl Account {
     }
     pub fn tls_alpn_01<'a>(
         &self,
+        crypto_provider: &CryptoProvider,
         challenges: &'a [Challenge],
         domain: String,
     ) -> Result<(&'a Challenge, CertifiedKey), AcmeError> {
@@ -198,9 +200,12 @@ impl Account {
         let cert = params.self_signed(&key_pair)?;
 
         let pk_bytes = key_pair.serialize_der();
-        let pk_der: PrivatePkcs8KeyDer = pk_bytes.into();
-        let pk_der: PrivateKeyDer = pk_der.into();
-        let pk = any_ecdsa_type(&pk_der).unwrap();
+        let pk_der: PrivatePkcs8KeyDer<'static> = pk_bytes.into();
+        let pk_der: PrivateKeyDer<'static> = pk_der.into();
+        let pk = crypto_provider
+            .key_provider
+            .load_private_key(pk_der)
+            .expect("rcgen-generated ECDSA P-256 key must load via the rustls crypto provider");
         let certified_key = CertifiedKey::new(vec![cert.der().clone()], pk);
         Ok((challenge, certified_key))
     }

--- a/src/caches/test.rs
+++ b/src/caches/test.rs
@@ -11,6 +11,7 @@ use std::sync::Arc;
 
 /// Test cache, which generates certificates for ACME incompatible test environments.
 /// ```rust
+/// # #[cfg(any(feature = "tls-ring", feature = "tls-aws-lc-rs"))] {
 /// # use tokio_rustls_acme::{AcmeConfig};
 /// # use tokio_rustls_acme::caches::{DirCache, TestCache};
 /// # let test_environment = true;
@@ -19,6 +20,7 @@ use std::sync::Arc;
 /// if test_environment {
 ///     config = config.cache(TestCache::new());
 /// }
+/// # }
 /// ```
 #[derive(Clone)]
 pub struct TestCache<EC: Debug = std::io::Error, EA: Debug = std::io::Error> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -28,13 +28,14 @@ pub struct AcmeConfig<EC: Debug, EA: Debug = EC> {
 }
 
 impl AcmeConfig<Infallible, Infallible> {
-    /// Creates a new [AcmeConfig] instance.
+    /// Creates an [`AcmeConfig`] backed by webpki-roots trust anchors.
     ///
-    /// The new [AcmeConfig] instance will initially have no cache, and its type parameters for
-    /// error types will be `Infallible` since the cache cannot return an error. The methods to set
-    /// a cache will change the error types to match those returned by the supplied cache.
+    /// Uses the [`CryptoProvider`] selected by the enabled crate feature
+    /// (`tls-ring` or `tls-aws-lc-rs`). When both or neither feature is
+    /// enabled the provider is ambiguous; use
+    /// [`AcmeConfig::new_with_crypto_provider`] in that case.
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// # use tokio_rustls_acme::AcmeConfig;
     /// use tokio_rustls_acme::caches::DirCache;
     /// let config = AcmeConfig::new(["example.com"]).cache(DirCache::new("./rustls_acme_cache"));
@@ -42,11 +43,11 @@ impl AcmeConfig<Infallible, Infallible> {
     ///
     /// Due to limited support for type parameter inference in Rust (see
     /// [RFC213](https://github.com/rust-lang/rfcs/blob/master/text/0213-defaulted-type-params.md)),
-    /// [AcmeConfig::new] is not (yet) generic over the [AcmeConfig]'s type parameters.
-    /// An uncached instance of [AcmeConfig] with particular type parameters can be created using
-    /// [NoCache].
+    /// [`AcmeConfig::new`] is not (yet) generic over the [`AcmeConfig`]'s type parameters.
+    /// An uncached instance of [`AcmeConfig`] with particular type parameters can be created using
+    /// [`NoCache`](crate::caches::NoCache).
     ///
-    /// ```rust
+    /// ```rust,no_run
     /// # use tokio_rustls_acme::AcmeConfig;
     /// use tokio_rustls_acme::caches::NoCache;
     /// # type EC = std::io::Error;
@@ -54,24 +55,21 @@ impl AcmeConfig<Infallible, Infallible> {
     /// let config: AcmeConfig<EC, EA> = AcmeConfig::new(["example.com"]).cache(NoCache::new());
     /// ```
     ///
+    /// # Panics
+    ///
+    /// Panics if both `tls-ring` and `tls-aws-lc-rs` are enabled, or if
+    /// neither is. Both cases leave the provider undetermined; reach for
+    /// [`AcmeConfig::new_with_crypto_provider`] instead.
     #[cfg(feature = "tls-webpki-roots")]
     pub fn new(domains: impl IntoIterator<Item = impl AsRef<str>>) -> Self {
-        let client_config = Arc::new(
-            ClientConfig::builder()
-                .with_root_certificates(Self::webpki_root_store())
-                .with_no_client_auth(),
-        );
-        Self::new_with_client_tls_config(domains, client_config)
+        Self::new_with_crypto_provider(domains, Self::default_crypto_provider())
     }
 
-    /// Same as [AcmeConfig::new] but with an explicit [`CryptoProvider`].
+    /// Same as [`AcmeConfig::new`] but with an explicit [`CryptoProvider`].
     ///
-    /// Builds the internal [`ClientConfig`] with `crypto_provider` instead of
-    /// rustls's process-wide default, and stores it on the config so the
-    /// state machine and acceptor use the same provider end-to-end. Use this
-    /// when you want the convenience of webpki-roots trust anchors without
-    /// relying on rustls's default-provider lookup (e.g. when both the `ring`
-    /// and `aws-lc-rs` features are on, or when neither is).
+    /// Lets the caller pick the provider regardless of which crate features
+    /// are enabled. The same provider is used for the HTTPS client, the
+    /// TLS handshake, and key parsing.
     #[cfg(feature = "tls-webpki-roots")]
     pub fn new_with_crypto_provider(
         domains: impl IntoIterator<Item = impl AsRef<str>>,
@@ -85,6 +83,29 @@ impl AcmeConfig<Infallible, Infallible> {
                 .with_no_client_auth(),
         );
         Self::new_with_client_tls_config(domains, client_config)
+    }
+
+    #[cfg(feature = "tls-webpki-roots")]
+    fn default_crypto_provider() -> Arc<CryptoProvider> {
+        #[cfg(all(feature = "tls-ring", not(feature = "tls-aws-lc-rs")))]
+        {
+            Arc::new(rustls::crypto::ring::default_provider())
+        }
+        #[cfg(all(feature = "tls-aws-lc-rs", not(feature = "tls-ring")))]
+        {
+            Arc::new(rustls::crypto::aws_lc_rs::default_provider())
+        }
+        #[cfg(any(
+            all(feature = "tls-ring", feature = "tls-aws-lc-rs"),
+            not(any(feature = "tls-ring", feature = "tls-aws-lc-rs")),
+        ))]
+        {
+            panic!(
+                "AcmeConfig::new requires exactly one of the `tls-ring` or \
+                 `tls-aws-lc-rs` crate features to be enabled; use \
+                 AcmeConfig::new_with_crypto_provider to choose explicitly"
+            )
+        }
     }
 
     #[cfg(feature = "tls-webpki-roots")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,6 +5,7 @@ use crate::caches::{BoxedErrCache, CompositeCache, NoCache};
 use crate::{AccountCache, Cache, CertCache};
 use crate::{AcmeState, Incoming};
 use futures::Stream;
+use rustls::crypto::CryptoProvider;
 use rustls::{ClientConfig, ServerConfig};
 use std::convert::Infallible;
 use std::fmt::Debug;
@@ -21,6 +22,7 @@ pub struct AcmeConfig<EC: Debug, EA: Debug = EC> {
     pub(crate) contact: Vec<String>,
     pub(crate) cache: Box<dyn Cache<EC = EC, EA = EA>>,
     pub(crate) eab: Option<ExternalAccountKey>,
+    pub(crate) crypto_provider: Option<Arc<CryptoProvider>>,
 }
 
 impl AcmeConfig<Infallible, Infallible> {
@@ -79,6 +81,7 @@ impl AcmeConfig<Infallible, Infallible> {
             contact: vec![],
             cache: Box::new(NoCache::new()),
             eab: None,
+            crypto_provider: None,
         }
     }
 }
@@ -139,6 +142,7 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeConfig<EC, EA> {
             contact: self.contact,
             cache: Box::new(cache),
             eab: self.eab,
+            crypto_provider: self.crypto_provider,
         }
     }
     pub fn cache_compose<CC: 'static + CertCache, CA: 'static + AccountCache>(
@@ -157,6 +161,23 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeConfig<EC, EA> {
             None => self.cache(NoCache::<C::EC, C::EA>::new()),
         }
     }
+
+    /// Sets the [`CryptoProvider`] used for the TLS handshake and for parsing
+    /// private keys from issued certificates.
+    ///
+    /// When unset, the process-wide default returned by
+    /// [`CryptoProvider::get_default`] is used. If no default has been
+    /// installed, the resolver panics on first use; install one beforehand
+    /// (e.g. with [`rustls::crypto::ring::default_provider()`] followed by
+    /// [`CryptoProvider::install_default`]) or call this method.
+    ///
+    /// Setting an explicit provider is required to use this crate without any
+    /// of rustls's built-in crypto features (`ring`, `aws-lc-rs`) enabled.
+    pub fn crypto_provider(mut self, crypto_provider: Arc<CryptoProvider>) -> Self {
+        self.crypto_provider = Some(crypto_provider);
+        self
+    }
+
     pub fn state(self) -> AcmeState<EC, EA> {
         AcmeState::new(self)
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -24,7 +24,7 @@ pub struct AcmeConfig<EC: Debug, EA: Debug = EC> {
     pub(crate) contact: Vec<String>,
     pub(crate) cache: Box<dyn Cache<EC = EC, EA = EA>>,
     pub(crate) eab: Option<ExternalAccountKey>,
-    pub(crate) crypto_provider: Option<Arc<CryptoProvider>>,
+    pub(crate) crypto_provider: Arc<CryptoProvider>,
 }
 
 impl AcmeConfig<Infallible, Infallible> {
@@ -78,15 +78,13 @@ impl AcmeConfig<Infallible, Infallible> {
         crypto_provider: Arc<CryptoProvider>,
     ) -> Self {
         let client_config = Arc::new(
-            ClientConfig::builder_with_provider(crypto_provider.clone())
+            ClientConfig::builder_with_provider(crypto_provider)
                 .with_protocol_versions(DEFAULT_VERSIONS)
                 .expect("rustls DEFAULT_VERSIONS is always valid")
                 .with_root_certificates(Self::webpki_root_store())
                 .with_no_client_auth(),
         );
-        let mut config = Self::new_with_client_tls_config(domains, client_config);
-        config.crypto_provider = Some(crypto_provider);
-        config
+        Self::new_with_client_tls_config(domains, client_config)
     }
 
     #[cfg(feature = "tls-webpki-roots")]
@@ -105,6 +103,10 @@ impl AcmeConfig<Infallible, Infallible> {
     /// Creates a config that uses `client_config` for ACME directory and
     /// order requests.
     ///
+    /// The [`CryptoProvider`] is read from `client_config` and reused for
+    /// the TLS handshake and key parsing, so the whole crate runs on the
+    /// same provider as the HTTPS client.
+    ///
     /// Use this when you need to control the trust store or crypto provider
     /// of the HTTPS client. Otherwise prefer [`AcmeConfig::new`] or
     /// [`AcmeConfig::new_with_crypto_provider`].
@@ -112,6 +114,7 @@ impl AcmeConfig<Infallible, Infallible> {
         domains: impl IntoIterator<Item = impl AsRef<str>>,
         client_config: Arc<ClientConfig>,
     ) -> Self {
+        let crypto_provider = client_config.crypto_provider().clone();
         AcmeConfig {
             client_config,
             directory_url: LETS_ENCRYPT_STAGING_DIRECTORY.into(),
@@ -119,14 +122,19 @@ impl AcmeConfig<Infallible, Infallible> {
             contact: vec![],
             cache: Box::new(NoCache::new()),
             eab: None,
-            crypto_provider: None,
+            crypto_provider,
         }
     }
 }
 
 impl<EC: 'static + Debug, EA: 'static + Debug> AcmeConfig<EC, EA> {
-    /// Set custom `rustls::ClientConfig` for ACME API calls.
+    /// Sets a custom [`ClientConfig`] for ACME API calls.
+    ///
+    /// The [`CryptoProvider`] is read from `client_config` and reused for
+    /// the TLS handshake and key parsing, keeping the whole crate on a
+    /// single provider.
     pub fn client_tls_config(mut self, client_config: Arc<ClientConfig>) -> Self {
+        self.crypto_provider = client_config.crypto_provider().clone();
         self.client_config = client_config;
         self
     }
@@ -198,22 +206,6 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeConfig<EC, EA> {
             Some(cache) => self.cache(cache),
             None => self.cache(NoCache::<C::EC, C::EA>::new()),
         }
-    }
-
-    /// Sets the [`CryptoProvider`] used for the TLS handshake and for parsing
-    /// private keys from issued certificates.
-    ///
-    /// When unset, the process-wide default returned by
-    /// [`CryptoProvider::get_default`] is used. If no default has been
-    /// installed, the resolver panics on first use; install one beforehand
-    /// (e.g. with [`rustls::crypto::ring::default_provider()`] followed by
-    /// [`CryptoProvider::install_default`]) or call this method.
-    ///
-    /// Setting an explicit provider is required to use this crate without any
-    /// of rustls's built-in crypto features (`ring`, `aws-lc-rs`) enabled.
-    pub fn crypto_provider(mut self, crypto_provider: Arc<CryptoProvider>) -> Self {
-        self.crypto_provider = Some(crypto_provider);
-        self
     }
 
     /// Returns the [`AcmeState`] that drives ordering, renewal, and caching.

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,6 +6,8 @@ use crate::{AccountCache, Cache, CertCache};
 use crate::{AcmeState, Incoming};
 use futures::Stream;
 use rustls::crypto::CryptoProvider;
+#[cfg(feature = "rustls-tls-webpki-roots")]
+use rustls::DEFAULT_VERSIONS;
 use rustls::{ClientConfig, ServerConfig};
 use std::convert::Infallible;
 use std::fmt::Debug;
@@ -54,6 +56,41 @@ impl AcmeConfig<Infallible, Infallible> {
     ///
     #[cfg(feature = "rustls-tls-webpki-roots")]
     pub fn new(domains: impl IntoIterator<Item = impl AsRef<str>>) -> Self {
+        let client_config = Arc::new(
+            ClientConfig::builder()
+                .with_root_certificates(Self::webpki_root_store())
+                .with_no_client_auth(),
+        );
+        Self::new_with_client_tls_config(domains, client_config)
+    }
+
+    /// Same as [AcmeConfig::new] but with an explicit [`CryptoProvider`].
+    ///
+    /// Builds the internal [`ClientConfig`] with `crypto_provider` instead of
+    /// rustls's process-wide default, and stores it on the config so the
+    /// state machine and acceptor use the same provider end-to-end. Use this
+    /// when you want the convenience of webpki-roots trust anchors without
+    /// relying on rustls's default-provider lookup (e.g. when both the `ring`
+    /// and `aws-lc-rs` features are on, or when neither is).
+    #[cfg(feature = "rustls-tls-webpki-roots")]
+    pub fn new_with_crypto_provider(
+        domains: impl IntoIterator<Item = impl AsRef<str>>,
+        crypto_provider: Arc<CryptoProvider>,
+    ) -> Self {
+        let client_config = Arc::new(
+            ClientConfig::builder_with_provider(crypto_provider.clone())
+                .with_protocol_versions(DEFAULT_VERSIONS)
+                .expect("rustls DEFAULT_VERSIONS is always valid")
+                .with_root_certificates(Self::webpki_root_store())
+                .with_no_client_auth(),
+        );
+        let mut config = Self::new_with_client_tls_config(domains, client_config);
+        config.crypto_provider = Some(crypto_provider);
+        config
+    }
+
+    #[cfg(feature = "rustls-tls-webpki-roots")]
+    fn webpki_root_store() -> rustls::RootCertStore {
         let mut root_store = rustls::RootCertStore::empty();
         root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {
             rustls::pki_types::TrustAnchor {
@@ -62,12 +99,7 @@ impl AcmeConfig<Infallible, Infallible> {
                 name_constraints: ta.name_constraints.clone(),
             }
         }));
-        let client_config = Arc::new(
-            ClientConfig::builder()
-                .with_root_certificates(root_store)
-                .with_no_client_auth(),
-        );
-        Self::new_with_client_tls_config(domains, client_config)
+        root_store
     }
 
     pub fn new_with_client_tls_config(

--- a/src/config.rs
+++ b/src/config.rs
@@ -30,10 +30,11 @@ pub struct AcmeConfig<EC: Debug, EA: Debug = EC> {
 impl AcmeConfig<Infallible, Infallible> {
     /// Creates an [`AcmeConfig`] backed by webpki-roots trust anchors.
     ///
-    /// Uses the [`CryptoProvider`] selected by the enabled crate feature
-    /// (`tls-ring` or `tls-aws-lc-rs`). When both or neither feature is
-    /// enabled the provider is ambiguous; use
-    /// [`AcmeConfig::new_with_crypto_provider`] in that case.
+    /// Picks ring when the `tls-ring` feature is enabled (the default),
+    /// otherwise aws-lc-rs. The same provider is used for the HTTPS client,
+    /// the TLS handshake, and key parsing. Available only when at least one
+    /// of `tls-ring` or `tls-aws-lc-rs` is enabled; if neither is, use
+    /// [`AcmeConfig::new_with_crypto_provider`].
     ///
     /// ```rust,no_run
     /// # use tokio_rustls_acme::AcmeConfig;
@@ -54,13 +55,10 @@ impl AcmeConfig<Infallible, Infallible> {
     /// # type EA = EC;
     /// let config: AcmeConfig<EC, EA> = AcmeConfig::new(["example.com"]).cache(NoCache::new());
     /// ```
-    ///
-    /// # Panics
-    ///
-    /// Panics if both `tls-ring` and `tls-aws-lc-rs` are enabled, or if
-    /// neither is. Both cases leave the provider undetermined; reach for
-    /// [`AcmeConfig::new_with_crypto_provider`] instead.
-    #[cfg(feature = "tls-webpki-roots")]
+    #[cfg(all(
+        feature = "tls-webpki-roots",
+        any(feature = "tls-ring", feature = "tls-aws-lc-rs")
+    ))]
     pub fn new(domains: impl IntoIterator<Item = impl AsRef<str>>) -> Self {
         Self::new_with_crypto_provider(domains, Self::default_crypto_provider())
     }
@@ -85,26 +83,18 @@ impl AcmeConfig<Infallible, Infallible> {
         Self::new_with_client_tls_config(domains, client_config)
     }
 
-    #[cfg(feature = "tls-webpki-roots")]
+    #[cfg(all(
+        feature = "tls-webpki-roots",
+        any(feature = "tls-ring", feature = "tls-aws-lc-rs")
+    ))]
     fn default_crypto_provider() -> Arc<CryptoProvider> {
-        #[cfg(all(feature = "tls-ring", not(feature = "tls-aws-lc-rs")))]
+        #[cfg(feature = "tls-ring")]
         {
             Arc::new(rustls::crypto::ring::default_provider())
         }
         #[cfg(all(feature = "tls-aws-lc-rs", not(feature = "tls-ring")))]
         {
             Arc::new(rustls::crypto::aws_lc_rs::default_provider())
-        }
-        #[cfg(any(
-            all(feature = "tls-ring", feature = "tls-aws-lc-rs"),
-            not(any(feature = "tls-ring", feature = "tls-aws-lc-rs")),
-        ))]
-        {
-            panic!(
-                "AcmeConfig::new requires exactly one of the `tls-ring` or \
-                 `tls-aws-lc-rs` crate features to be enabled; use \
-                 AcmeConfig::new_with_crypto_provider to choose explicitly"
-            )
         }
     }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -102,6 +102,12 @@ impl AcmeConfig<Infallible, Infallible> {
         root_store
     }
 
+    /// Creates a config that uses `client_config` for ACME directory and
+    /// order requests.
+    ///
+    /// Use this when you need to control the trust store or crypto provider
+    /// of the HTTPS client. Otherwise prefer [`AcmeConfig::new`] or
+    /// [`AcmeConfig::new_with_crypto_provider`].
     pub fn new_with_client_tls_config(
         domains: impl IntoIterator<Item = impl AsRef<str>>,
         client_config: Arc<ClientConfig>,
@@ -210,6 +216,7 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeConfig<EC, EA> {
         self
     }
 
+    /// Returns the [`AcmeState`] that drives ordering, renewal, and caching.
     pub fn state(self) -> AcmeState<EC, EA> {
         AcmeState::new(self)
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -6,7 +6,7 @@ use crate::{AccountCache, Cache, CertCache};
 use crate::{AcmeState, Incoming};
 use futures::Stream;
 use rustls::crypto::CryptoProvider;
-#[cfg(feature = "rustls-tls-webpki-roots")]
+#[cfg(feature = "tls-webpki-roots")]
 use rustls::DEFAULT_VERSIONS;
 use rustls::{ClientConfig, ServerConfig};
 use std::convert::Infallible;
@@ -54,7 +54,7 @@ impl AcmeConfig<Infallible, Infallible> {
     /// let config: AcmeConfig<EC, EA> = AcmeConfig::new(["example.com"]).cache(NoCache::new());
     /// ```
     ///
-    #[cfg(feature = "rustls-tls-webpki-roots")]
+    #[cfg(feature = "tls-webpki-roots")]
     pub fn new(domains: impl IntoIterator<Item = impl AsRef<str>>) -> Self {
         let client_config = Arc::new(
             ClientConfig::builder()
@@ -72,7 +72,7 @@ impl AcmeConfig<Infallible, Infallible> {
     /// when you want the convenience of webpki-roots trust anchors without
     /// relying on rustls's default-provider lookup (e.g. when both the `ring`
     /// and `aws-lc-rs` features are on, or when neither is).
-    #[cfg(feature = "rustls-tls-webpki-roots")]
+    #[cfg(feature = "tls-webpki-roots")]
     pub fn new_with_crypto_provider(
         domains: impl IntoIterator<Item = impl AsRef<str>>,
         crypto_provider: Arc<CryptoProvider>,
@@ -89,7 +89,7 @@ impl AcmeConfig<Infallible, Infallible> {
         config
     }
 
-    #[cfg(feature = "rustls-tls-webpki-roots")]
+    #[cfg(feature = "tls-webpki-roots")]
     fn webpki_root_store() -> rustls::RootCertStore {
         let mut root_store = rustls::RootCertStore::empty();
         root_store.extend(webpki_roots::TLS_SERVER_ROOTS.iter().map(|ta| {

--- a/src/incoming.rs
+++ b/src/incoming.rs
@@ -10,6 +10,10 @@ use std::task::{Context, Poll};
 use tokio::io::{AsyncRead, AsyncWrite};
 use tokio_rustls::{server::TlsStream, Accept};
 
+/// [`Stream`] of accepted application TLS connections.
+///
+/// Folds ACME order and renewal work into the same poll loop, so polling
+/// this stream advances both the certificate state machine and TCP accept.
 pub struct Incoming<
     TCP: AsyncRead + AsyncWrite + Unpin,
     ETCP,

--- a/src/incoming.rs
+++ b/src/incoming.rs
@@ -2,7 +2,7 @@ use crate::acceptor::{AcmeAccept, AcmeAcceptor};
 use crate::AcmeState;
 use futures::stream::{FusedStream, FuturesUnordered};
 use futures::Stream;
-use rustls::ServerConfig;
+use rustls::{ServerConfig, DEFAULT_VERSIONS};
 use std::fmt::Debug;
 use std::pin::Pin;
 use std::sync::Arc;
@@ -65,7 +65,9 @@ impl<
         acceptor: AcmeAcceptor,
         alpn_protocols: Vec<Vec<u8>>,
     ) -> Self {
-        let mut server_config = ServerConfig::builder()
+        let mut server_config = ServerConfig::builder_with_provider(state.crypto_provider())
+            .with_protocol_versions(DEFAULT_VERSIONS)
+            .expect("rustls DEFAULT_VERSIONS is always valid")
             .with_no_client_auth()
             .with_cert_resolver(state.resolver());
         server_config.alpn_protocols = alpn_protocols;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,11 +13,12 @@
 //!
 //! ## Crypto provider
 //!
-//! The default `ring` feature selects [ring] as rustls's crypto backend. To
-//! use [aws-lc-rs] instead, disable default features and enable `aws-lc-rs`:
+//! The default `tls-ring` feature selects [ring] as rustls's crypto
+//! backend. To use [aws-lc-rs] instead, disable default features and
+//! enable `tls-aws-lc-rs`:
 //!
 //! ```toml
-//! tokio-rustls-acme = { version = "*", default-features = false, features = ["aws-lc-rs", "rustls-tls-webpki-roots"] }
+//! tokio-rustls-acme = { version = "*", default-features = false, features = ["tls-aws-lc-rs", "tls-webpki-roots"] }
 //! ```
 //!
 //! Both features can be enabled together; in that case rustls has no

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-//! An easy-to-use, async compatible [ACME] client library using [rustls] with [ring].
+//! An easy-to-use, async compatible [ACME] client library using [rustls].
 //! The validation mechanism used is tls-alpn-01, which allows serving acme challenge responses and
 //! regular TLS traffic on the same port.
 //!
@@ -11,9 +11,20 @@
 //! The goal is to provide a [Let's Encrypt](https://letsencrypt.org/) compatible TLS serving and
 //! certificate management using a simple and flexible stream based API.
 //!
-//! This crate uses [ring] as [rustls]'s backend, instead of [aws-lc-rs]. This generally makes it
-//! much easier to compile. If you'd like to use [aws-lc-rs] as [rustls]'s backend, we're open to
-//! contributions with the necessary `Cargo.toml` changes and feature-flags to enable you to do so.
+//! ## Crypto provider
+//!
+//! The default `ring` feature selects [ring] as rustls's crypto backend. To
+//! use [aws-lc-rs] instead, disable default features and enable `aws-lc-rs`:
+//!
+//! ```toml
+//! tokio-rustls-acme = { version = "*", default-features = false, features = ["aws-lc-rs", "rustls-tls-webpki-roots"] }
+//! ```
+//!
+//! Both features can be enabled together; in that case rustls has no
+//! auto-installable default and the caller must either install one with
+//! [`rustls::crypto::CryptoProvider::install_default`] or pass it via
+//! [`AcmeConfig::crypto_provider`]. The same applies when neither feature
+//! is enabled.
 //!
 //! To use tokio-rustls-acme add the following lines to your `Cargo.toml`:
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -27,10 +27,10 @@
 //! tokio-rustls-acme = { version = "*", default-features = false, features = ["tls-aws-lc-rs", "tls-webpki-roots"] }
 //! ```
 //!
-//! With both features (or neither) enabled, [`AcmeConfig::new`] panics
-//! because the provider is ambiguous; use
+//! With both features enabled, [`AcmeConfig::new`] picks ring. When
+//! neither is enabled it is unavailable; use
 //! [`AcmeConfig::new_with_crypto_provider`] or
-//! [`AcmeConfig::new_with_client_tls_config`] to pick one explicitly.
+//! [`AcmeConfig::new_with_client_tls_config`] in that case.
 //!
 //! To use tokio-rustls-acme add the following lines to your `Cargo.toml`:
 //!
@@ -46,6 +46,8 @@
 //! well as accepting TLS connections, which are handed over to the caller on success.
 //!
 //! ```rust,no_run
+//! # #[cfg(any(feature = "tls-ring", feature = "tls-aws-lc-rs"))]
+//! # mod example {
 //! use tokio::io::AsyncWriteExt;
 //! use futures::StreamExt;
 //! use tokio_rustls_acme::{AcmeConfig, caches::DirCache};
@@ -77,6 +79,8 @@
 //! Content-Type: text/plain; charset=utf-8
 //!
 //! Hello Tls!"#;
+//! # }
+//! # fn main() {}
 //! ```
 //!
 //! `examples/high_level.rs` implements a "Hello Tls!" server similar to the one above, which accepts

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,12 @@
 //!
 //! ## Crypto provider
 //!
+//! The crate uses one [`rustls::crypto::CryptoProvider`] end-to-end: for
+//! the HTTPS client, the TLS handshake, and key parsing. It is taken from
+//! the [`rustls::ClientConfig`] passed to [`AcmeConfig`] (or built from
+//! the chosen crate feature when [`AcmeConfig::new`] is used). The crate
+//! never reads or installs the process-wide default provider.
+//!
 //! The default `tls-ring` feature selects [ring] as rustls's crypto
 //! backend. To use [aws-lc-rs] instead, disable default features and
 //! enable `tls-aws-lc-rs`:
@@ -21,11 +27,10 @@
 //! tokio-rustls-acme = { version = "*", default-features = false, features = ["tls-aws-lc-rs", "tls-webpki-roots"] }
 //! ```
 //!
-//! Both features can be enabled together; in that case rustls has no
-//! auto-installable default and the caller must either install one with
-//! [`rustls::crypto::CryptoProvider::install_default`] or pass it via
-//! [`AcmeConfig::crypto_provider`]. The same applies when neither feature
-//! is enabled.
+//! With both features (or neither) enabled, [`AcmeConfig::new`] panics
+//! because the provider is ambiguous; use
+//! [`AcmeConfig::new_with_crypto_provider`] or
+//! [`AcmeConfig::new_with_client_tls_config`] to pick one explicitly.
 //!
 //! To use tokio-rustls-acme add the following lines to your `Cargo.toml`:
 //!

--- a/src/resolver.rs
+++ b/src/resolver.rs
@@ -5,6 +5,8 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::sync::Mutex;
 
+/// Cert resolver that serves the issued certificate to application traffic
+/// and per-domain validation certificates to `tls-alpn-01` clients.
 #[derive(Debug)]
 pub struct ResolvesServerCertAcme {
     inner: Mutex<Inner>,

--- a/src/state.rs
+++ b/src/state.rs
@@ -11,6 +11,7 @@ use futures::future::try_join_all;
 use futures::{ready, FutureExt, Stream};
 use rcgen::{CertificateParams, DistinguishedName, Error as RcgenError, PKCS_ECDSA_P256_SHA256};
 use rustls::crypto::ring::sign::any_ecdsa_type;
+use rustls::crypto::CryptoProvider;
 use rustls::pki_types::{CertificateDer as RustlsCertificate, PrivateKeyDer, PrivatePkcs8KeyDer};
 use rustls::sign::CertifiedKey;
 use rustls::ServerConfig;
@@ -131,6 +132,13 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
 
     pub fn acceptor(&self) -> AcmeAcceptor {
         AcmeAcceptor::new(self.resolver())
+    }
+
+    pub fn acceptor_with_crypto_provider(
+        &self,
+        crypto_provider: Arc<CryptoProvider>,
+    ) -> AcmeAcceptor {
+        AcmeAcceptor::new_with_crypto_provider(self.resolver(), crypto_provider)
     }
 
     #[cfg(feature = "axum")]

--- a/src/state.rs
+++ b/src/state.rs
@@ -32,6 +32,10 @@ pub fn after(d: std::time::Duration) -> Timer {
     Box::pin(tokio::time::sleep(d))
 }
 
+/// Drives ACME orders and renewals, surfacing lifecycle events as a [`Stream`].
+///
+/// Owns the [`ResolvesServerCertAcme`] populated as new certificates are
+/// issued. Construct one from [`AcmeConfig::state`].
 #[allow(clippy::type_complexity)]
 pub struct AcmeState<EC: Debug = Infallible, EA: Debug = EC> {
     config: Arc<AcmeConfig<EC, EA>>,
@@ -103,6 +107,11 @@ pub enum CertParseError {
 }
 
 impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
+    /// Wraps `tcp_incoming` so each connection is dispatched to ACME
+    /// validation or to application TLS, returning an [`Incoming`] stream.
+    ///
+    /// `alpn_protocols` lists application protocols offered to clients,
+    /// most preferred first. Pass an empty `Vec` to disable ALPN.
     pub fn incoming<
         TCP: AsyncRead + AsyncWrite + Unpin,
         ETCP,
@@ -116,6 +125,11 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
         Incoming::new(tcp_incoming, self, acceptor, alpn_protocols)
     }
 
+    /// Like [`AcmeState::incoming`] but uses `server_config` for the
+    /// application TLS handshake.
+    ///
+    /// Use this when the caller needs to customize the rustls
+    /// [`ServerConfig`] beyond ALPN (e.g. session storage, mTLS).
     pub fn incoming_with_server<
         TCP: AsyncRead + AsyncWrite + Unpin,
         ETCP,
@@ -129,6 +143,7 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
         Incoming::new_with_server(tcp_incoming, self, acceptor, server_config)
     }
 
+    /// Returns an [`AcmeAcceptor`] for use with custom TCP accept loops.
     pub fn acceptor(&self) -> AcmeAcceptor {
         AcmeAcceptor::new(self.resolver(), self.crypto_provider())
     }
@@ -160,9 +175,13 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
     ) -> crate::axum::AxumAcceptor {
         crate::axum::AxumAcceptor::new(self.acceptor(), rustls_config)
     }
+    /// Returns the certificate resolver populated by this state machine.
     pub fn resolver(&self) -> Arc<ResolvesServerCertAcme> {
         self.resolver.clone()
     }
+
+    /// Creates a state machine from `config`. Equivalent to
+    /// [`AcmeConfig::state`].
     pub fn new(config: AcmeConfig<EC, EA>) -> Self {
         let config = Arc::new(config);
         Self {

--- a/src/state.rs
+++ b/src/state.rs
@@ -10,7 +10,6 @@ use chrono::{DateTime, TimeZone, Utc};
 use futures::future::try_join_all;
 use futures::{ready, FutureExt, Stream};
 use rcgen::{CertificateParams, DistinguishedName, Error as RcgenError, PKCS_ECDSA_P256_SHA256};
-use rustls::crypto::ring::sign::any_ecdsa_type;
 use rustls::crypto::CryptoProvider;
 use rustls::pki_types::{CertificateDer as RustlsCertificate, PrivateKeyDer, PrivatePkcs8KeyDer};
 use rustls::sign::CertifiedKey;
@@ -131,14 +130,27 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
     }
 
     pub fn acceptor(&self) -> AcmeAcceptor {
-        AcmeAcceptor::new(self.resolver())
+        AcmeAcceptor::new(self.resolver(), self.crypto_provider())
     }
 
-    pub fn acceptor_with_crypto_provider(
-        &self,
-        crypto_provider: Arc<CryptoProvider>,
-    ) -> AcmeAcceptor {
-        AcmeAcceptor::new_with_crypto_provider(self.resolver(), crypto_provider)
+    /// Returns the [`CryptoProvider`] configured on the [`AcmeConfig`], or the
+    /// process-wide default if none was set.
+    ///
+    /// # Panics
+    ///
+    /// Panics if no provider was configured and no default has been installed
+    /// with [`CryptoProvider::install_default`]. See
+    /// [`AcmeConfig::crypto_provider`](crate::AcmeConfig::crypto_provider).
+    pub fn crypto_provider(&self) -> Arc<CryptoProvider> {
+        self.config
+            .crypto_provider
+            .clone()
+            .or_else(|| CryptoProvider::get_default().cloned())
+            .expect(
+                "no rustls CryptoProvider available; \
+                 set one with AcmeConfig::crypto_provider() or \
+                 CryptoProvider::install_default()",
+            )
     }
 
     #[cfg(feature = "axum")]
@@ -181,15 +193,18 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
             wait: None,
         }
     }
-    fn parse_cert(pem: &[u8]) -> Result<(CertifiedKey, [DateTime<Utc>; 2]), CertParseError> {
+    fn parse_cert(
+        crypto_provider: &CryptoProvider,
+        pem: &[u8],
+    ) -> Result<(CertifiedKey, [DateTime<Utc>; 2]), CertParseError> {
         let mut pems = pem::parse_many(pem)?;
         if pems.len() < 2 {
             return Err(CertParseError::TooFewPem(pems.len()));
         }
         let pk_bytes = pems.remove(0).into_contents();
-        let pk_der: PrivatePkcs8KeyDer = pk_bytes.into();
-        let pk: PrivateKeyDer = pk_der.into();
-        let pk = match any_ecdsa_type(&pk) {
+        let pk_der: PrivatePkcs8KeyDer<'static> = pk_bytes.into();
+        let pk_der: PrivateKeyDer<'static> = pk_der.into();
+        let pk = match crypto_provider.key_provider.load_private_key(pk_der) {
             Ok(pk) => pk,
             Err(_) => return Err(CertParseError::InvalidPrivateKey),
         };
@@ -209,7 +224,8 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
 
     #[allow(clippy::result_large_err)]
     fn process_cert(&mut self, pem: Vec<u8>, cached: bool) -> Event<EC, EA> {
-        let (cert, validity) = match (Self::parse_cert(&pem), cached) {
+        let provider = self.crypto_provider();
+        let (cert, validity) = match (Self::parse_cert(&provider, &pem), cached) {
             (Ok(r), _) => r,
             (Err(err), cached) => {
                 return match cached {
@@ -242,6 +258,7 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
     }
     async fn order(
         config: Arc<AcmeConfig<EC, EA>>,
+        crypto_provider: Arc<CryptoProvider>,
         resolver: Arc<ResolvesServerCertAcme>,
         key_pair: Vec<u8>,
     ) -> Result<Vec<u8>, OrderError> {
@@ -265,10 +282,9 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
         loop {
             match order.status {
                 OrderStatus::Pending => {
-                    let auth_futures = order
-                        .authorizations
-                        .iter()
-                        .map(|url| Self::authorize(&config, &resolver, &account, url));
+                    let auth_futures = order.authorizations.iter().map(|url| {
+                        Self::authorize(&config, &crypto_provider, &resolver, &account, url)
+                    });
                     try_join_all(auth_futures).await?;
                     log::info!("completed all authorizations");
                     order = account.order(&config.client_config, &order_url).await?;
@@ -311,6 +327,7 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
     }
     async fn authorize(
         config: &AcmeConfig<EC, EA>,
+        crypto_provider: &CryptoProvider,
         resolver: &ResolvesServerCertAcme,
         account: &Account,
         url: &String,
@@ -321,7 +338,7 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
                 let Identifier::Dns(domain) = auth.identifier;
                 log::info!("trigger challenge for {}", &domain);
                 let (challenge, auth_key) =
-                    account.tls_alpn_01(&auth.challenges, domain.clone())?;
+                    account.tls_alpn_01(crypto_provider, &auth.challenges, domain.clone())?;
                 resolver.set_auth_key(domain.clone(), Arc::new(auth_key));
                 account
                     .challenge(&config.client_config, &challenge.url)
@@ -431,8 +448,9 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
             };
             let config = self.config.clone();
             let resolver = self.resolver.clone();
+            let crypto_provider = self.crypto_provider();
             self.order = Some(Box::pin({
-                Self::order(config.clone(), resolver.clone(), account_key)
+                Self::order(config, crypto_provider, resolver, account_key)
             }));
         }
     }

--- a/src/state.rs
+++ b/src/state.rs
@@ -148,24 +148,9 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
         AcmeAcceptor::new(self.resolver(), self.crypto_provider())
     }
 
-    /// Returns the [`CryptoProvider`] configured on the [`AcmeConfig`], or the
-    /// process-wide default if none was set.
-    ///
-    /// # Panics
-    ///
-    /// Panics if no provider was configured and no default has been installed
-    /// with [`CryptoProvider::install_default`]. See
-    /// [`AcmeConfig::crypto_provider`](crate::AcmeConfig::crypto_provider).
+    /// Returns the [`CryptoProvider`] used by this state machine.
     pub fn crypto_provider(&self) -> Arc<CryptoProvider> {
-        self.config
-            .crypto_provider
-            .clone()
-            .or_else(|| CryptoProvider::get_default().cloned())
-            .expect(
-                "no rustls CryptoProvider available; \
-                 set one with AcmeConfig::crypto_provider() or \
-                 CryptoProvider::install_default()",
-            )
+        self.config.crypto_provider.clone()
     }
 
     #[cfg(feature = "axum")]

--- a/tests/crypto_provider.rs
+++ b/tests/crypto_provider.rs
@@ -6,10 +6,10 @@
 //! `parse_cert` path (which uses `provider.key_provider.load_private_key`)
 //! and the runtime handshake.
 //!
-//! Skipped entirely when the crate is built without a built-in provider:
-//! the tests need one or both of `ring`/`aws-lc-rs` to construct a provider.
-
-#![cfg(any(feature = "ring", feature = "aws-lc-rs"))]
+//! `rustls` is also a dev-dependency with the `ring` feature on, so tests
+//! can construct a provider even when the crate is built without either of
+//! the `ring`/`aws-lc-rs` crate features. That mirrors how a downstream
+//! user would integrate a third-party provider.
 
 use std::{convert::TryFrom, io, sync::Arc, time::Duration};
 
@@ -143,4 +143,23 @@ async fn ring_server_aws_lc_rs_client() {
     let (resolver, ca_pem) = deploy_test_cert(server_provider.clone()).await;
     let leaf = tls_handshake(resolver, server_provider, client_provider, &ca_pem).await;
     assert!(!leaf.as_ref().is_empty());
+}
+
+/// Verifies the crate works when neither `ring` nor `aws-lc-rs` crate
+/// features are enabled and no default provider has been installed. The
+/// caller must supply a `CryptoProvider` explicitly via
+/// `AcmeConfig::crypto_provider`.
+///
+/// Compiled only in that configuration. The `rustls` dev-dependency carries
+/// the `ring` feature so the test can still construct a provider, just as
+/// a downstream user would do with their own provider crate.
+#[cfg(not(any(feature = "ring", feature = "aws-lc-rs")))]
+#[tokio::test]
+async fn no_built_in_provider() {
+    assert!(
+        rustls::crypto::CryptoProvider::get_default().is_none(),
+        "no provider should be installed in this configuration",
+    );
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    roundtrip(provider).await;
 }

--- a/tests/crypto_provider.rs
+++ b/tests/crypto_provider.rs
@@ -11,7 +11,7 @@
 //! the `ring`/`aws-lc-rs` crate features. That mirrors how a downstream
 //! user would integrate a third-party provider.
 
-#![cfg(feature = "rustls-tls-webpki-roots")]
+#![cfg(feature = "tls-webpki-roots")]
 
 use std::{convert::TryFrom, io, sync::Arc, time::Duration};
 
@@ -108,14 +108,14 @@ async fn roundtrip(provider: Arc<CryptoProvider>) {
     assert!(!leaf.as_ref().is_empty(), "leaf cert must not be empty");
 }
 
-#[cfg(feature = "ring")]
+#[cfg(feature = "tls-ring")]
 #[tokio::test]
 async fn ring_provider_explicit() {
     let provider = Arc::new(rustls::crypto::ring::default_provider());
     roundtrip(provider).await;
 }
 
-#[cfg(feature = "aws-lc-rs")]
+#[cfg(feature = "tls-aws-lc-rs")]
 #[tokio::test]
 async fn aws_lc_rs_provider_explicit() {
     let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
@@ -124,7 +124,7 @@ async fn aws_lc_rs_provider_explicit() {
 
 /// Mixed handshake: server runs ring, client runs aws-lc-rs. Confirms the
 /// `CertifiedKey` resolved by `AcmeState` interoperates across providers.
-#[cfg(all(feature = "ring", feature = "aws-lc-rs"))]
+#[cfg(all(feature = "tls-ring", feature = "tls-aws-lc-rs"))]
 #[tokio::test]
 async fn ring_server_aws_lc_rs_client() {
     let server_provider = Arc::new(rustls::crypto::ring::default_provider());
@@ -135,15 +135,15 @@ async fn ring_server_aws_lc_rs_client() {
     assert!(!leaf.as_ref().is_empty());
 }
 
-/// Verifies the crate works when neither `ring` nor `aws-lc-rs` crate
-/// features are enabled and no default provider has been installed. The
-/// caller must supply a `CryptoProvider` explicitly via
+/// Verifies the crate works when neither `tls-ring` nor `tls-aws-lc-rs`
+/// crate features are enabled and no default provider has been installed.
+/// The caller must supply a `CryptoProvider` explicitly via
 /// `AcmeConfig::crypto_provider`.
 ///
 /// Compiled only in that configuration. The `rustls` dev-dependency carries
 /// the `ring` feature so the test can still construct a provider, just as
 /// a downstream user would do with their own provider crate.
-#[cfg(not(any(feature = "ring", feature = "aws-lc-rs")))]
+#[cfg(not(any(feature = "tls-ring", feature = "tls-aws-lc-rs")))]
 #[tokio::test]
 async fn no_built_in_provider() {
     assert!(

--- a/tests/crypto_provider.rs
+++ b/tests/crypto_provider.rs
@@ -1,0 +1,146 @@
+//! End-to-end TLS handshake tests against `AcmeConfig::crypto_provider`.
+//!
+//! Each test installs a specific `CryptoProvider` on the config, drives the
+//! state machine until `TestCache` yields a self-signed chain, and verifies a
+//! TLS handshake succeeds against the resolver. This exercises both the
+//! `parse_cert` path (which uses `provider.key_provider.load_private_key`)
+//! and the runtime handshake.
+//!
+//! Skipped entirely when the crate is built without a built-in provider:
+//! the tests need one or both of `ring`/`aws-lc-rs` to construct a provider.
+
+#![cfg(any(feature = "ring", feature = "aws-lc-rs"))]
+
+use std::{convert::TryFrom, io, sync::Arc, time::Duration};
+
+use futures::StreamExt;
+use rustls::{
+    crypto::CryptoProvider,
+    pki_types::{CertificateDer, ServerName},
+    ClientConfig, RootCertStore, DEFAULT_VERSIONS,
+};
+use tokio_rustls_acme::{caches::TestCache, AcmeConfig, EventOk, ResolvesServerCertAcme};
+
+const DOMAIN: &str = "example.com";
+
+fn client_config_with_roots(provider: Arc<CryptoProvider>, ca_pem: &[u8]) -> Arc<ClientConfig> {
+    let mut roots = RootCertStore::empty();
+    for p in pem::parse_many(ca_pem).expect("parse CA PEM") {
+        roots
+            .add(CertificateDer::from(p.into_contents()))
+            .expect("add CA to root store");
+    }
+    Arc::new(
+        ClientConfig::builder_with_provider(provider)
+            .with_protocol_versions(DEFAULT_VERSIONS)
+            .unwrap()
+            .with_root_certificates(roots)
+            .with_no_client_auth(),
+    )
+}
+
+fn empty_client_config(provider: Arc<CryptoProvider>) -> Arc<ClientConfig> {
+    Arc::new(
+        ClientConfig::builder_with_provider(provider)
+            .with_protocol_versions(DEFAULT_VERSIONS)
+            .unwrap()
+            .with_root_certificates(RootCertStore::empty())
+            .with_no_client_auth(),
+    )
+}
+
+/// Run the state machine against `TestCache` until a cached cert is deployed.
+async fn deploy_test_cert(provider: Arc<CryptoProvider>) -> (Arc<ResolvesServerCertAcme>, String) {
+    let test_cache = TestCache::<io::Error, io::Error>::new();
+    let ca_pem = test_cache.ca_pem().to_string();
+
+    let mut state =
+        AcmeConfig::new_with_client_tls_config([DOMAIN], empty_client_config(provider.clone()))
+            .crypto_provider(provider)
+            .cache(test_cache)
+            .state();
+    let resolver = state.resolver();
+
+    tokio::time::timeout(Duration::from_secs(5), async {
+        loop {
+            match state.next().await {
+                Some(Ok(EventOk::DeployedCachedCert)) => return,
+                Some(Ok(_)) => {}
+                Some(Err(err)) => panic!("state error: {:?}", err),
+                None => panic!("state stream ended"),
+            }
+        }
+    })
+    .await
+    .expect("timed out waiting for cached cert deploy");
+
+    (resolver, ca_pem)
+}
+
+/// In-process TLS handshake against the resolver. Returns the leaf cert.
+async fn tls_handshake(
+    resolver: Arc<ResolvesServerCertAcme>,
+    server_provider: Arc<CryptoProvider>,
+    client_provider: Arc<CryptoProvider>,
+    ca_pem: &str,
+) -> CertificateDer<'static> {
+    let server_config = Arc::new(
+        rustls::ServerConfig::builder_with_provider(server_provider)
+            .with_protocol_versions(DEFAULT_VERSIONS)
+            .unwrap()
+            .with_no_client_auth()
+            .with_cert_resolver(resolver),
+    );
+    let acceptor = tokio_rustls::TlsAcceptor::from(server_config);
+
+    let client_config = client_config_with_roots(client_provider, ca_pem.as_bytes());
+    let connector = tokio_rustls::TlsConnector::from(client_config);
+
+    let (client_io, server_io) = tokio::io::duplex(4096);
+    let server_name = ServerName::try_from(DOMAIN).unwrap().to_owned();
+
+    let (client_result, server_result) = tokio::join!(
+        connector.connect(server_name, client_io),
+        acceptor.accept(server_io),
+    );
+
+    server_result.expect("server handshake");
+    let client_tls = client_result.expect("client handshake");
+    let (_, conn) = client_tls.get_ref();
+    conn.peer_certificates().expect("peer certs")[0]
+        .clone()
+        .into_owned()
+}
+
+async fn roundtrip(provider: Arc<CryptoProvider>) {
+    let (resolver, ca_pem) = deploy_test_cert(provider.clone()).await;
+    let leaf = tls_handshake(resolver, provider.clone(), provider, &ca_pem).await;
+    assert!(!leaf.as_ref().is_empty(), "leaf cert must not be empty");
+}
+
+#[cfg(feature = "ring")]
+#[tokio::test]
+async fn ring_provider_explicit() {
+    let provider = Arc::new(rustls::crypto::ring::default_provider());
+    roundtrip(provider).await;
+}
+
+#[cfg(feature = "aws-lc-rs")]
+#[tokio::test]
+async fn aws_lc_rs_provider_explicit() {
+    let provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+    roundtrip(provider).await;
+}
+
+/// Mixed handshake: server runs ring, client runs aws-lc-rs. Confirms the
+/// `CertifiedKey` resolved by `AcmeState` interoperates across providers.
+#[cfg(all(feature = "ring", feature = "aws-lc-rs"))]
+#[tokio::test]
+async fn ring_server_aws_lc_rs_client() {
+    let server_provider = Arc::new(rustls::crypto::ring::default_provider());
+    let client_provider = Arc::new(rustls::crypto::aws_lc_rs::default_provider());
+
+    let (resolver, ca_pem) = deploy_test_cert(server_provider.clone()).await;
+    let leaf = tls_handshake(resolver, server_provider, client_provider, &ca_pem).await;
+    assert!(!leaf.as_ref().is_empty());
+}

--- a/tests/crypto_provider.rs
+++ b/tests/crypto_provider.rs
@@ -11,6 +11,8 @@
 //! the `ring`/`aws-lc-rs` crate features. That mirrors how a downstream
 //! user would integrate a third-party provider.
 
+#![cfg(feature = "rustls-tls-webpki-roots")]
+
 use std::{convert::TryFrom, io, sync::Arc, time::Duration};
 
 use futures::StreamExt;
@@ -39,26 +41,14 @@ fn client_config_with_roots(provider: Arc<CryptoProvider>, ca_pem: &[u8]) -> Arc
     )
 }
 
-fn empty_client_config(provider: Arc<CryptoProvider>) -> Arc<ClientConfig> {
-    Arc::new(
-        ClientConfig::builder_with_provider(provider)
-            .with_protocol_versions(DEFAULT_VERSIONS)
-            .unwrap()
-            .with_root_certificates(RootCertStore::empty())
-            .with_no_client_auth(),
-    )
-}
-
 /// Run the state machine against `TestCache` until a cached cert is deployed.
 async fn deploy_test_cert(provider: Arc<CryptoProvider>) -> (Arc<ResolvesServerCertAcme>, String) {
     let test_cache = TestCache::<io::Error, io::Error>::new();
     let ca_pem = test_cache.ca_pem().to_string();
 
-    let mut state =
-        AcmeConfig::new_with_client_tls_config([DOMAIN], empty_client_config(provider.clone()))
-            .crypto_provider(provider)
-            .cache(test_cache)
-            .state();
+    let mut state = AcmeConfig::new_with_crypto_provider([DOMAIN], provider)
+        .cache(test_cache)
+        .state();
     let resolver = state.resolver();
 
     tokio::time::timeout(Duration::from_secs(5), async {

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -13,8 +13,9 @@ use std::{convert::TryFrom, io, path::PathBuf, sync::Arc, time::Duration};
 
 use futures::StreamExt;
 use rustls::{
+    crypto::CryptoProvider,
     pki_types::{CertificateDer, ServerName},
-    ClientConfig, RootCertStore, ServerConfig,
+    ClientConfig, RootCertStore, ServerConfig, DEFAULT_VERSIONS,
 };
 use tokio_rustls::TlsAcceptor;
 use tokio_rustls_acme::{
@@ -37,6 +38,13 @@ fn load_minica_cert() -> Vec<u8> {
     std::fs::read(&path).unwrap_or_else(|e| panic!("failed to read {}: {}", path, e))
 }
 
+/// Returns a fresh ring crypto provider. The pebble tests pin themselves to
+/// ring (via the dev-dependency) regardless of which crate features are on,
+/// so they never depend on the process-wide default provider.
+fn test_crypto_provider() -> Arc<CryptoProvider> {
+    Arc::new(rustls::crypto::ring::default_provider())
+}
+
 /// Build a rustls ClientConfig that trusts Pebble's minica root (for ACME API calls).
 fn pebble_client_config() -> Arc<ClientConfig> {
     let minica_pem = load_minica_cert();
@@ -49,7 +57,9 @@ fn pebble_client_config() -> Arc<ClientConfig> {
             .expect("failed to add minica cert to root store");
     }
     Arc::new(
-        ClientConfig::builder()
+        ClientConfig::builder_with_provider(test_crypto_provider())
+            .with_protocol_versions(DEFAULT_VERSIONS)
+            .unwrap()
             .with_root_certificates(root_store)
             .with_no_client_auth(),
     )
@@ -175,14 +185,18 @@ async fn verify_tls_handshake_for(
     domain: &str,
 ) -> Vec<CertificateDer<'static>> {
     let server_config = Arc::new(
-        ServerConfig::builder()
+        ServerConfig::builder_with_provider(test_crypto_provider())
+            .with_protocol_versions(DEFAULT_VERSIONS)
+            .unwrap()
             .with_no_client_auth()
             .with_cert_resolver(resolver),
     );
     let acceptor = TlsAcceptor::from(server_config);
 
     let client_config = Arc::new(
-        ClientConfig::builder()
+        ClientConfig::builder_with_provider(test_crypto_provider())
+            .with_protocol_versions(DEFAULT_VERSIONS)
+            .unwrap()
             .with_root_certificates(root_store)
             .with_no_client_auth(),
     );

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -65,8 +65,16 @@ fn pebble_client_config() -> Arc<ClientConfig> {
     )
 }
 
-/// Insecure reqwest client for Pebble management API calls.
+/// Reqwest client that talks to Pebble's management API.
+///
+/// Installs ring as the process-wide default `CryptoProvider` so reqwest's
+/// `rustls-no-provider` build path can construct its own TLS config without
+/// panicking. This is fine for the pebble tests because the only crypto
+/// provider in scope here is ring (pinned via the `rustls` dev-dependency)
+/// and the assertion in `tests/crypto_provider.rs` runs in a separate test
+/// binary.
 fn http_client() -> reqwest::Client {
+    let _ = rustls::crypto::ring::default_provider().install_default();
     reqwest::Client::builder()
         .danger_accept_invalid_certs(true)
         .build()


### PR DESCRIPTION
Uses a single `rustls::crypto::CryptoProvider` throughout the crate, and makes it configurable both with feature flags and with explicit seleection. Adds `AcmeConfig::new_with_crypto_provider` for the explicit-provider case, and makes the rustls crypto features additive (`tls-ring` default, `tls-aws-lc-rs` opt-in). `AcmeConfig::new` is now gated on either of the tls features being enabled (and uses `ring` if both are).

## Breaking Changes

* renamed: the `rustls-tls-webpki-roots` feature is now `tls-webpki-roots`.
* changed: the rustls `ring` feature is no longer hard-coded. The new `tls-ring` (default) and `tls-aws-lc-rs` features are additive and control which crypto provider rustls compiles with. Default behaviour is unchanged because `tls-ring` is in the default feature set.
* added: `AcmeConfig::new_with_crypto_provider(domains, provider)`, a constructor that builds a webpki-roots-backed `ClientConfig` from a caller-supplied `CryptoProvider`. The same provider is used for the HTTPS client, the TLS handshake, and key parsing.
* changed: `AcmeConfig::new_with_client_tls_config` now adopts the `CryptoProvider` from the supplied `ClientConfig` and uses it for the TLS handshake and key parsing, not only for ACME HTTPS calls. The `client_tls_config` builder method does the same when it swaps the config.
* changed: `AcmeConfig::new` is gated on `tls-webpki-roots` and at least one of `tls-ring` or `tls-aws-lc-rs`. With both enabled it picks ring. When neither is enabled the method is absent; use `AcmeConfig::new_with_crypto_provider` in that case.
* changed: `Account::tls_alpn_01` (in the unstable `acme` module) now takes a `&CryptoProvider` for loading the challenge cert's private key.
