### PR TITLE
feat: add dns-persist-01 challenge support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 /target
 /.idea
 /cache
+/pebble.minica.pem

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -2,10 +2,12 @@
 description = "Start Pebble ACME test server"
 script = '''
 docker compose -f docker-compose.pebble.yml up -d
-echo "Waiting for Pebble to be ready..."
+echo "Waiting for Pebble and challtestsrv to be ready..."
 for i in $(seq 1 30); do
-    if curl -sk https://localhost:14000/dir > /dev/null 2>&1; then
-        echo "Pebble is ready"
+    if curl -sk https://localhost:14000/dir > /dev/null 2>&1 \
+        && curl -sk https://localhost:14001/dir > /dev/null 2>&1 \
+        && curl -s http://localhost:8055/ > /dev/null 2>&1; then
+        echo "Pebble and challtestsrv are ready"
         exit 0
     fi
     sleep 1

--- a/README.md
+++ b/README.md
@@ -37,8 +37,10 @@
 > Original implementation based on https://github.com/FlorianUekermann/rustls-acme. 
 
 An easy-to-use, async compatible [ACME] client library using [rustls] with [ring].
-The validation mechanism used is tls-alpn-01, which allows serving acme challenge responses and
-regular TLS traffic on the same port.
+The default validation mechanism is tls-alpn-01, which allows serving acme challenge responses and
+regular TLS traffic on the same port. The dns-persist-01 challenge is also supported via
+`AcmeConfig::challenge_type`, validated against a standing `_validation-persist` DNS TXT record that
+binds the domain to the client's ACME account (the record must be published out of band).
 
 Is designed to use the tokio runtime, if you need support for other runtimes take a look
 at the original implementation [rustls-acme](https://github.com/FlorianUekermann/rustls-acme).

--- a/docker-compose.pebble.yml
+++ b/docker-compose.pebble.yml
@@ -1,4 +1,7 @@
 services:
+  # Default Pebble instance with validation bypassed (PEBBLE_VA_ALWAYS_VALID).
+  # The tls-alpn-01 tests run the resolver in-process and never expose a port to
+  # Pebble, so real validation could not reach them.
   pebble:
     image: ghcr.io/letsencrypt/pebble:latest
     command: ["-config", "/test/config/pebble-config.json"]
@@ -11,3 +14,32 @@ services:
       PEBBLE_VA_NOSLEEP: "1"
       PEBBLE_VA_ALWAYS_VALID: "1"
       PEBBLE_WFE_NONCEREJECT: "0"
+
+  # Second Pebble instance that performs real validation, using challtestsrv as
+  # its DNS resolver. The dns-persist-01 tests use this instance so the VA
+  # actually queries the _validation-persist TXT record we publish.
+  pebble-dns:
+    image: ghcr.io/letsencrypt/pebble:latest
+    command:
+      - "-config"
+      - "/test/config/pebble-config.json"
+      - "-dnsserver"
+      - "challtestsrv:8053"
+    ports:
+      - "14001:14000"
+      - "15001:15000"
+    volumes:
+      - ./test/pebble-config.json:/test/config/pebble-config.json:ro
+    environment:
+      PEBBLE_VA_NOSLEEP: "1"
+      PEBBLE_WFE_NONCEREJECT: "0"
+    depends_on:
+      - challtestsrv
+
+  # Mock DNS server with an HTTP management API on port 8055, used to publish the
+  # dns-persist-01 validation records that pebble-dns checks.
+  challtestsrv:
+    image: ghcr.io/letsencrypt/pebble-challtestsrv:latest
+    command: ["-defaultIPv6", "", "-defaultIPv4", ""]
+    ports:
+      - "8055:8055"

--- a/src/acme.rs
+++ b/src/acme.rs
@@ -23,6 +23,12 @@ pub const LETS_ENCRYPT_PRODUCTION_DIRECTORY: &str =
     "https://acme-v02.api.letsencrypt.org/directory";
 pub const ACME_TLS_ALPN_NAME: &[u8] = b"acme-tls/1";
 
+/// The DNS label under which a `dns-persist-01` validation record is published.
+///
+/// The full record name for a domain is `_validation-persist.<domain>`, see
+/// [`dns_persist_01_record_name`].
+pub const DNS_PERSIST_01_LABEL: &str = "_validation-persist";
+
 #[derive(Debug)]
 pub struct Account {
     pub key_pair: EcdsaKeyPair,
@@ -204,6 +210,75 @@ impl Account {
         let certified_key = CertifiedKey::new(vec![cert.der().clone()], pk);
         Ok((challenge, certified_key))
     }
+
+    /// Selects the `dns-persist-01` challenge from a list of challenges.
+    ///
+    /// Unlike [`Account::tls_alpn_01`], this returns no key material: a
+    /// `dns-persist-01` challenge is satisfied by a standing DNS TXT record that
+    /// the domain operator publishes out of band, not by anything the client
+    /// serves during the handshake. See [`dns_persist_01_record_name`] and
+    /// [`dns_persist_01_record_value`] for constructing that record.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`AcmeError::NoDnsPersist01Challenge`] if the authorization does
+    /// not offer a `dns-persist-01` challenge.
+    pub fn dns_persist_01<'a>(
+        &self,
+        challenges: &'a [Challenge],
+    ) -> Result<&'a Challenge, AcmeError> {
+        challenges
+            .iter()
+            .find(|c| c.typ == ChallengeType::DnsPersist01)
+            .ok_or(AcmeError::NoDnsPersist01Challenge)
+    }
+}
+
+/// Returns the DNS name at which a `dns-persist-01` validation record must be
+/// published for `domain`.
+///
+/// The returned name has no trailing dot, for example
+/// `_validation-persist.example.com`.
+pub fn dns_persist_01_record_name(domain: &str) -> String {
+    format!("{DNS_PERSIST_01_LABEL}.{domain}")
+}
+
+/// Builds the TXT record value for a `dns-persist-01` validation record.
+///
+/// The value follows the `issue-value` syntax of RFC 8659 section 4.2, as
+/// required by the `dns-persist-01` draft: the issuer domain name followed by a
+/// mandatory `accounturi` parameter. When `wildcard` is set, a `policy=wildcard`
+/// parameter is appended, which the draft requires for authorizing wildcard
+/// certificates.
+///
+/// `issuer_domain_name` must be one of the issuer domain names advertised by the
+/// CA (see [`Challenge::issuer_domain_names`]), and `account_uri` must be the
+/// URI of the ACME account that will request issuance (see [`Account::kid`]).
+///
+/// # Examples
+///
+/// ```
+/// # use tokio_rustls_acme::acme::dns_persist_01_record_value;
+/// let value = dns_persist_01_record_value(
+///     "letsencrypt.org",
+///     "https://acme-v02.api.letsencrypt.org/acme/acct/1234567890",
+///     false,
+/// );
+/// assert_eq!(
+///     value,
+///     "letsencrypt.org; accounturi=https://acme-v02.api.letsencrypt.org/acme/acct/1234567890",
+/// );
+/// ```
+pub fn dns_persist_01_record_value(
+    issuer_domain_name: &str,
+    account_uri: &str,
+    wildcard: bool,
+) -> String {
+    let mut value = format!("{issuer_domain_name}; accounturi={account_uri}");
+    if wildcard {
+        value.push_str("; policy=wildcard");
+    }
+    value
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -245,14 +320,31 @@ impl ExternalAccountKey {
     }
 }
 
-#[derive(Debug, Deserialize, Eq, PartialEq)]
+/// An ACME challenge type.
+///
+/// Used both for deserializing the `type` field of challenge objects and for
+/// selecting the challenge this crate uses to prove domain control (see
+/// [`AcmeConfig::challenge_type`]). Only [`ChallengeType::TlsAlpn01`] and
+/// [`ChallengeType::DnsPersist01`] are supported as a selection.
+///
+/// [`AcmeConfig::challenge_type`]: crate::AcmeConfig::challenge_type
+#[derive(Debug, Clone, Copy, Deserialize, Default, Eq, PartialEq)]
 pub enum ChallengeType {
     #[serde(rename = "http-01")]
     Http01,
     #[serde(rename = "dns-01")]
     Dns01,
+    /// The `tls-alpn-01` challenge, served on the same port as regular TLS
+    /// traffic. This is the default and requires no external setup.
+    #[default]
     #[serde(rename = "tls-alpn-01")]
     TlsAlpn01,
+    /// The `dns-persist-01` challenge, validated against a standing
+    /// `_validation-persist` DNS TXT record that binds the domain to an ACME
+    /// account. The operator must publish this record out of band; see
+    /// [`dns_persist_01_record_value`].
+    #[serde(rename = "dns-persist-01")]
+    DnsPersist01,
     #[serde(other)]
     Unknown,
 }
@@ -283,6 +375,13 @@ pub struct Auth {
     pub status: AuthStatus,
     pub identifier: Identifier,
     pub challenges: Vec<Challenge>,
+    /// Whether this authorization is for a wildcard identifier.
+    ///
+    /// Set by the server (RFC 8555 section 7.1.4) when the order requested a
+    /// `*.` name. A `dns-persist-01` record authorizing such an order needs a
+    /// `policy=wildcard` parameter, see [`dns_persist_01_record_value`].
+    #[serde(default)]
+    pub wildcard: bool,
 }
 
 #[derive(Debug, Deserialize)]
@@ -310,6 +409,22 @@ pub struct Challenge {
     pub url: String,
     #[serde(default)]
     pub token: String,
+    /// The URI of the ACME account, as echoed by the CA on a `dns-persist-01`
+    /// challenge.
+    ///
+    /// When present, it is the value the CA expects as the `accounturi`
+    /// parameter of the `_validation-persist` TXT record, and it matches the
+    /// account's [`Account::kid`]. It is informational and may be empty (not all
+    /// CAs populate it); clients should use their own [`Account::kid`] when
+    /// building the record.
+    #[serde(rename = "accounturi", default)]
+    pub account_uri: String,
+    /// The issuer domain names the CA accepts in a `dns-persist-01` record.
+    ///
+    /// The TXT record must lead with one of these names. Present only on
+    /// `dns-persist-01` challenges.
+    #[serde(rename = "issuer-domain-names", default)]
+    pub issuer_domain_names: Vec<String>,
     pub error: Option<Problem>,
 }
 
@@ -341,6 +456,8 @@ pub enum AcmeError {
     MissingHeader(&'static str),
     #[error("no tls-alpn-01 challenge found")]
     NoTlsAlpn01Challenge,
+    #[error("no dns-persist-01 challenge found")]
+    NoDnsPersist01Challenge,
 }
 
 fn get_header(response: &Response, header: &'static str) -> Result<String, AcmeError> {

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,6 @@
 use crate::acme::{
-    ExternalAccountKey, LETS_ENCRYPT_PRODUCTION_DIRECTORY, LETS_ENCRYPT_STAGING_DIRECTORY,
+    ChallengeType, ExternalAccountKey, LETS_ENCRYPT_PRODUCTION_DIRECTORY,
+    LETS_ENCRYPT_STAGING_DIRECTORY,
 };
 use crate::caches::{BoxedErrCache, CompositeCache, NoCache};
 use crate::{AccountCache, Cache, CertCache};
@@ -21,6 +22,7 @@ pub struct AcmeConfig<EC: Debug, EA: Debug = EC> {
     pub(crate) contact: Vec<String>,
     pub(crate) cache: Box<dyn Cache<EC = EC, EA = EA>>,
     pub(crate) eab: Option<ExternalAccountKey>,
+    pub(crate) challenge_type: ChallengeType,
 }
 
 impl AcmeConfig<Infallible, Infallible> {
@@ -79,6 +81,7 @@ impl AcmeConfig<Infallible, Infallible> {
             contact: vec![],
             cache: Box::new(NoCache::new()),
             eab: None,
+            challenge_type: ChallengeType::default(),
         }
     }
 }
@@ -87,6 +90,27 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeConfig<EC, EA> {
     /// Set custom `rustls::ClientConfig` for ACME API calls.
     pub fn client_tls_config(mut self, client_config: Arc<ClientConfig>) -> Self {
         self.client_config = client_config;
+        self
+    }
+    /// Selects the ACME challenge type used to prove control of the domains.
+    ///
+    /// Defaults to [`ChallengeType::TlsAlpn01`], which is served on the same
+    /// port as regular TLS traffic and needs no external setup.
+    ///
+    /// Set [`ChallengeType::DnsPersist01`] to validate against a standing
+    /// `_validation-persist` DNS TXT record instead. That record binds the
+    /// domain to this client's ACME account, so it must be published out of band
+    /// before issuance and the account must be reused across runs (configure a
+    /// persistent [`cache`](Self::cache)). The required record name and value
+    /// are logged at info level on each authorization; build them directly with
+    /// [`dns_persist_01_record_name`](crate::acme::dns_persist_01_record_name)
+    /// and
+    /// [`dns_persist_01_record_value`](crate::acme::dns_persist_01_record_value).
+    ///
+    /// Only [`ChallengeType::TlsAlpn01`] and [`ChallengeType::DnsPersist01`] are
+    /// supported; selecting any other variant fails the order.
+    pub fn challenge_type(mut self, challenge_type: ChallengeType) -> Self {
+        self.challenge_type = challenge_type;
         self
     }
     pub fn directory(mut self, directory_url: impl AsRef<str>) -> Self {
@@ -139,6 +163,7 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeConfig<EC, EA> {
             contact: self.contact,
             cache: Box::new(cache),
             eab: self.eab,
+            challenge_type: self.challenge_type,
         }
     }
     pub fn cache_compose<CC: 'static + CertCache, CA: 'static + AccountCache>(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 //! An easy-to-use, async compatible [ACME] client library using [rustls] with [ring].
-//! The validation mechanism used is tls-alpn-01, which allows serving acme challenge responses and
-//! regular TLS traffic on the same port.
+//! The default validation mechanism is tls-alpn-01, which allows serving acme challenge responses
+//! and regular TLS traffic on the same port. The dns-persist-01 challenge is also supported, see
+//! [Challenge types](#challenge-types).
 //!
 //! Is designed to use the tokio runtime, if you need support for other runtimes take a look
 //! at the original implementation [rustls-acme](https://github.com/FlorianUekermann/rustls-acme).
@@ -94,6 +95,23 @@
 //! If you want to avoid different specializations based on cache type use the
 //! [AcmeConfig::cache_with_boxed_err] method to construct the an [AcmeConfig] object.
 //!
+//!
+//! ## Challenge types
+//!
+//! By default this crate proves domain control with the tls-alpn-01 challenge, which needs no
+//! setup beyond serving TLS on the configured port.
+//!
+//! Alternatively, [AcmeConfig::challenge_type] can select [acme::ChallengeType::DnsPersist01]
+//! ([dns-persist-01](https://datatracker.ietf.org/doc/draft-ietf-acme-dns-persist/)). That
+//! challenge is satisfied by a standing `_validation-persist` DNS TXT record that binds the domain
+//! to this client's ACME account, rather than by anything served during the handshake. Because the
+//! record must be published out of band before issuance, two things are required:
+//!
+//! - A persistent account, so the account URI the record is bound to stays stable across runs.
+//!   Configure a [Cache] (such as [caches::DirCache]).
+//! - The `_validation-persist.<domain>` TXT record, published through your DNS provider. The
+//!   required name and value are logged on each authorization and can be built directly with
+//!   [acme::dns_persist_01_record_name] and [acme::dns_persist_01_record_value].
 //!
 //! ## The acme module
 //!

--- a/src/state.rs
+++ b/src/state.rs
@@ -21,7 +21,8 @@ use x509_parser::parse_x509_certificate;
 
 use crate::acceptor::AcmeAcceptor;
 use crate::acme::{
-    Account, AcmeError, Auth, AuthStatus, Directory, Identifier, Order, OrderStatus,
+    dns_persist_01_record_name, dns_persist_01_record_value, Account, AcmeError, Auth, AuthStatus,
+    ChallengeType, Directory, Identifier, Order, OrderStatus,
 };
 use crate::{AcmeConfig, Incoming, ResolvesServerCertAcme};
 
@@ -88,6 +89,8 @@ pub enum OrderError {
     TooManyAttemptsAuth(String),
     #[error("order status stayed on processing too long")]
     ProcessingTimeout(Order),
+    #[error("unsupported challenge type: {0:?}")]
+    UnsupportedChallengeType(ChallengeType),
 }
 
 #[derive(Error, Debug)]
@@ -312,13 +315,36 @@ impl<EC: 'static + Debug, EA: 'static + Debug> AcmeState<EC, EA> {
             AuthStatus::Pending => {
                 let Identifier::Dns(domain) = auth.identifier;
                 log::info!("trigger challenge for {}", &domain);
-                let (challenge, auth_key) =
-                    account.tls_alpn_01(&auth.challenges, domain.clone())?;
-                resolver.set_auth_key(domain.clone(), Arc::new(auth_key));
+                let challenge_url = match config.challenge_type {
+                    ChallengeType::TlsAlpn01 => {
+                        let (challenge, auth_key) =
+                            account.tls_alpn_01(&auth.challenges, domain.clone())?;
+                        resolver.set_auth_key(domain.clone(), Arc::new(auth_key));
+                        challenge.url.clone()
+                    }
+                    ChallengeType::DnsPersist01 => {
+                        let challenge = account.dns_persist_01(&auth.challenges)?;
+                        // The validation record is published out of band by the
+                        // operator. Log exactly what it must contain so it can be
+                        // provisioned for this account. The account URI is our own
+                        // kid (the CA's `accounturi` field is only informational),
+                        // and the issuer domain name comes from the challenge.
+                        if let Some(issuer) = challenge.issuer_domain_names.first() {
+                            log::info!(
+                                "dns-persist-01 for {} requires TXT record {} with value {:?}",
+                                &domain,
+                                dns_persist_01_record_name(&domain),
+                                dns_persist_01_record_value(issuer, &account.kid, auth.wildcard),
+                            );
+                        }
+                        challenge.url.clone()
+                    }
+                    other => return Err(OrderError::UnsupportedChallengeType(other)),
+                };
                 account
-                    .challenge(&config.client_config, &challenge.url)
+                    .challenge(&config.client_config, &challenge_url)
                     .await?;
-                (domain, challenge.url.clone())
+                (domain, challenge_url)
             }
             AuthStatus::Valid => return Ok(()),
             _ => return Err(OrderError::BadAuth(auth)),

--- a/test/pebble-config.json
+++ b/test/pebble-config.json
@@ -8,6 +8,7 @@
     "tlsPort": 5001,
     "ocspResponderURL": "",
     "externalAccountBindingRequired": false,
+    "caaIdentities": ["pebble.letsencrypt.org"],
     "retryAfter": {
       "authz": 1,
       "order": 1

--- a/tests/pebble.rs
+++ b/tests/pebble.rs
@@ -18,12 +18,25 @@ use rustls::{
 };
 use tokio_rustls::TlsAcceptor;
 use tokio_rustls_acme::{
+    acme::{
+        dns_persist_01_record_name, dns_persist_01_record_value, Account, AuthStatus,
+        ChallengeType, Directory,
+    },
     caches::{DirCache, NoCache},
     AccountCache, AcmeConfig, CertCache, EventOk, ResolvesServerCertAcme,
 };
 
 const PEBBLE_DIRECTORY: &str = "https://localhost:14000/dir";
 const PEBBLE_MGMT: &str = "https://localhost:15000";
+/// Directory of the second Pebble instance, which performs real validation
+/// against challtestsrv. Used by the dns-persist-01 tests.
+const PEBBLE_DNS_DIRECTORY: &str = "https://localhost:14001/dir";
+const PEBBLE_DNS_MGMT: &str = "https://localhost:15001";
+/// Management API of the mock DNS server (pebble-challtestsrv).
+const CHALLTESTSRV: &str = "http://localhost:8055";
+/// Issuer domain name advertised by Pebble (its `caaIdentities`), which must
+/// lead the dns-persist-01 TXT record value.
+const PEBBLE_ISSUER_DOMAIN: &str = "pebble.letsencrypt.org";
 const TEST_DOMAIN: &str = "pebble-test.example.com";
 const TEST_DOMAINS: &[&str] = &[
     "pebble-multi-1.example.com",
@@ -66,6 +79,15 @@ fn http_client() -> reqwest::Client {
 /// Fetch Pebble's ACME-issued root + intermediate certs and build a root store
 /// for verifying certs issued by Pebble's CA.
 async fn pebble_acme_root_store() -> RootCertStore {
+    pebble_acme_root_store_at(PEBBLE_MGMT).await
+}
+
+/// Like [`pebble_acme_root_store`] but for a specific management API endpoint.
+///
+/// Each Pebble instance generates its own CA at startup, so certs issued by
+/// `pebble-dns` must be verified against roots fetched from its own management
+/// API (port 15001), not the default instance's.
+async fn pebble_acme_root_store_at(mgmt: &str) -> RootCertStore {
     let client = http_client();
     let mut root_store = RootCertStore::empty();
 
@@ -73,7 +95,7 @@ async fn pebble_acme_root_store() -> RootCertStore {
     // PEBBLE_ALTERNATE_ROOTS is enabled). 404s are expected and skipped.
     for kind in &["roots", "intermediates"] {
         for index in 0..2 {
-            let url = format!("{PEBBLE_MGMT}/{kind}/{index}");
+            let url = format!("{mgmt}/{kind}/{index}");
             let resp = client.get(&url).send().await.unwrap_or_else(|e| {
                 panic!("failed to reach Pebble management API at {}: {}", url, e)
             });
@@ -508,4 +530,256 @@ async fn test_multi_domain_san() {
         );
     }
     eprintln!("multi-domain SANs: {sans:?}");
+}
+
+// --- dns-persist-01 -------------------------------------------------------
+//
+// These tests run against the `pebble-dns` instance, which performs real
+// validation (PEBBLE_VA_ALWAYS_VALID is not set) and resolves DNS through
+// challtestsrv. We publish the `_validation-persist` TXT record via
+// challtestsrv's management API and let the VA verify it.
+
+/// Publish a TXT record at `host` (with trailing dot) via challtestsrv.
+async fn set_txt(host: &str, value: &str) {
+    let client = http_client();
+    let body = serde_json::json!({ "host": host, "value": value }).to_string();
+    let resp = client
+        .post(format!("{CHALLTESTSRV}/set-txt"))
+        .header("content-type", "application/json")
+        .body(body)
+        .send()
+        .await
+        .expect("challtestsrv set-txt request failed");
+    assert!(
+        resp.status().is_success(),
+        "challtestsrv set-txt returned {}",
+        resp.status()
+    );
+}
+
+/// Remove the TXT record at `host` (with trailing dot) via challtestsrv.
+async fn clear_txt(host: &str) {
+    let client = http_client();
+    let body = serde_json::json!({ "host": host }).to_string();
+    let _ = client
+        .post(format!("{CHALLTESTSRV}/clear-txt"))
+        .header("content-type", "application/json")
+        .body(body)
+        .send()
+        .await;
+}
+
+/// Register a fresh ACME account against `pebble-dns` and return it.
+async fn new_dns_account(client_config: &Arc<ClientConfig>) -> Account {
+    let directory = Directory::discover(client_config, PEBBLE_DNS_DIRECTORY)
+        .await
+        .expect("directory discovery failed");
+    let key_pair = Account::generate_key_pair();
+    Account::create_with_keypair(
+        client_config,
+        directory,
+        &Vec::<String>::new(),
+        &key_pair,
+        &None,
+    )
+    .await
+    .expect("account creation failed")
+}
+
+/// Poll an authorization until it leaves the pending state, returning the
+/// terminal status.
+async fn poll_auth_status(
+    client_config: &Arc<ClientConfig>,
+    account: &Account,
+    auth_url: &str,
+) -> AuthStatus {
+    for _ in 0..20 {
+        tokio::time::sleep(Duration::from_millis(500)).await;
+        let auth = account
+            .auth(client_config, auth_url)
+            .await
+            .expect("auth fetch failed");
+        match auth.status {
+            AuthStatus::Pending => continue,
+            other => return other,
+        }
+    }
+    panic!("authorization did not reach a terminal state in time");
+}
+
+/// A correctly provisioned `_validation-persist` record satisfies the challenge.
+///
+/// Drives the low-level `acme` module: order, read the dns-persist-01 challenge,
+/// publish the matching TXT record, respond, and confirm the VA marks the
+/// authorization valid. This exercises the real wire format end to end.
+#[tokio::test]
+#[ignore]
+async fn test_dns_persist_01_validates() {
+    let _ = simple_logger::init_with_level(log::Level::Info);
+    let domain = "dns-persist-ok.example.com";
+
+    let client_config = pebble_client_config();
+    let account = new_dns_account(&client_config).await;
+    let (_order_url, order) = account
+        .new_order(&client_config, vec![domain.to_string()])
+        .await
+        .expect("new_order failed");
+
+    let auth_url = &order.authorizations[0];
+    let auth = account
+        .auth(&client_config, auth_url)
+        .await
+        .expect("auth fetch failed");
+
+    let challenge = account
+        .dns_persist_01(&auth.challenges)
+        .expect("no dns-persist-01 challenge offered");
+
+    // The challenge advertises the accepted issuer domains. The accounturi field
+    // is informational and may be empty; when present it must equal our kid.
+    assert!(
+        challenge
+            .issuer_domain_names
+            .contains(&PEBBLE_ISSUER_DOMAIN.to_string()),
+        "expected issuer {} in {:?}",
+        PEBBLE_ISSUER_DOMAIN,
+        challenge.issuer_domain_names
+    );
+    assert!(
+        challenge.account_uri.is_empty() || challenge.account_uri == account.kid,
+        "challenge accounturi {:?} should be empty or equal the account kid {:?}",
+        challenge.account_uri,
+        account.kid
+    );
+
+    let record_name = format!("{}.", dns_persist_01_record_name(domain));
+    let record_value = dns_persist_01_record_value(PEBBLE_ISSUER_DOMAIN, &account.kid, false);
+    set_txt(&record_name, &record_value).await;
+
+    account
+        .challenge(&client_config, &challenge.url)
+        .await
+        .expect("challenge response failed");
+
+    let status = poll_auth_status(&client_config, &account, auth_url).await;
+    clear_txt(&record_name).await;
+    assert!(
+        matches!(status, AuthStatus::Valid),
+        "authorization should be valid, got {:?}",
+        status
+    );
+}
+
+/// A missing `_validation-persist` record fails validation.
+///
+/// The mirror of [`test_dns_persist_01_validates`] without publishing the
+/// record, confirming the VA actually checks DNS rather than rubber-stamping.
+#[tokio::test]
+#[ignore]
+async fn test_dns_persist_01_missing_record_fails() {
+    let _ = simple_logger::init_with_level(log::Level::Info);
+    let domain = "dns-persist-missing.example.com";
+
+    let client_config = pebble_client_config();
+    let account = new_dns_account(&client_config).await;
+
+    // Make sure no stale record lingers from a previous run.
+    clear_txt(&format!("{}.", dns_persist_01_record_name(domain))).await;
+
+    let (_order_url, order) = account
+        .new_order(&client_config, vec![domain.to_string()])
+        .await
+        .expect("new_order failed");
+    let auth_url = &order.authorizations[0];
+    let auth = account
+        .auth(&client_config, auth_url)
+        .await
+        .expect("auth fetch failed");
+    let challenge = account
+        .dns_persist_01(&auth.challenges)
+        .expect("no dns-persist-01 challenge offered");
+
+    account
+        .challenge(&client_config, &challenge.url)
+        .await
+        .expect("challenge response failed");
+
+    let status = poll_auth_status(&client_config, &account, auth_url).await;
+    assert!(
+        matches!(status, AuthStatus::Invalid),
+        "authorization should be invalid without a record, got {:?}",
+        status
+    );
+}
+
+/// The high-level state machine issues a certificate via dns-persist-01.
+///
+/// Registers the account up front to learn its kid, publishes the matching
+/// record, seeds the account into a cache so the state machine reuses it, then
+/// runs `AcmeConfig` with `ChallengeType::DnsPersist01` and verifies the
+/// resulting certificate serves a TLS handshake.
+#[tokio::test]
+#[ignore]
+async fn test_dns_persist_01_state_machine() {
+    let _ = simple_logger::init_with_level(log::Level::Info);
+    let domain = "dns-persist-hl.example.com";
+
+    let client_config = pebble_client_config();
+
+    // Register the account first so we know its kid, then publish the record.
+    // We keep the raw key bytes so the same account can be seeded into the cache
+    // and reused by the state machine.
+    let key_pair = Account::generate_key_pair();
+    let directory = Directory::discover(&client_config, PEBBLE_DNS_DIRECTORY)
+        .await
+        .expect("directory discovery failed");
+    let account = Account::create_with_keypair(
+        &client_config,
+        directory,
+        &Vec::<String>::new(),
+        &key_pair,
+        &None,
+    )
+    .await
+    .expect("account creation failed");
+
+    let record_name = format!("{}.", dns_persist_01_record_name(domain));
+    let record_value = dns_persist_01_record_value(PEBBLE_ISSUER_DOMAIN, &account.kid, false);
+    set_txt(&record_name, &record_value).await;
+
+    // Seed the account key into a cache so the state machine reuses the same
+    // account (and therefore the same kid the record is bound to).
+    let cache_dir = tempfile::tempdir().unwrap();
+    let cache_path: PathBuf = cache_dir.path().into();
+    DirCache::new(cache_path.clone())
+        .store_account(&[], PEBBLE_DNS_DIRECTORY, &key_pair)
+        .await
+        .expect("seeding account cache failed");
+
+    let config: AcmeConfig<io::Error> =
+        AcmeConfig::new_with_client_tls_config([domain], client_config)
+            .directory(PEBBLE_DNS_DIRECTORY)
+            .challenge_type(ChallengeType::DnsPersist01)
+            .cache(DirCache::new(cache_path));
+
+    let mut state = config.state();
+    let resolver = state.resolver();
+
+    let deploy = tokio::time::timeout(Duration::from_secs(30), async {
+        loop {
+            match state.next().await {
+                Some(Ok(EventOk::DeployedNewCert)) => return,
+                Some(Ok(event)) => eprintln!("event: {event:?}"),
+                Some(Err(err)) => panic!("ACME error: {:?}", err),
+                None => panic!("state stream ended unexpectedly"),
+            }
+        }
+    })
+    .await;
+    clear_txt(&record_name).await;
+    deploy.expect("timed out waiting for dns-persist-01 certificate");
+
+    let root_store = pebble_acme_root_store_at(PEBBLE_DNS_MGMT).await;
+    let peer_certs = verify_tls_handshake_for(resolver, root_store, domain).await;
+    assert!(!peer_certs.is_empty(), "should have received certificates");
 }


### PR DESCRIPTION
(draft PR authored with an LLM, not yet fully reviewed)

Add the dns-persist-01 ACME challenge (draft-ietf-acme-dns-persist) alongside the existing tls-alpn-01. It is selected with AcmeConfig::challenge_type and validated against a standing _validation-persist DNS TXT record that binds the domain to the client's ACME account, rather than anything served during the handshake. Because the record is published out of band, the order step logs the required name and value, and the acme module exposes dns_persist_01_record_name and dns_persist_01_record_value helpers to build it.

Parse the new challenge fields (accounturi, issuer-domain-names) and the authorization wildcard flag, and branch the order's authorize step per challenge type.

Test against Pebble end to end: add a second Pebble instance with real validation and a challtestsrv DNS mock, then cover a successful authorization, a missing-record failure, and full issuance through the high-level state machine.